### PR TITLE
Enable editing of project durations

### DIFF
--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -207,9 +207,39 @@ const ProjectsPrograms = ({
                         />
                       </td>
                       <td className="p-4">
-                        <div className="text-sm">
-                          <div>D: {project.designDuration}</div>
-                          <div>C: {project.constructionDuration}</div>
+                        <div className="flex flex-col gap-2 text-sm">
+                          <label className="flex items-center gap-2">
+                            <span className="text-gray-600">D:</span>
+                            <input
+                              type="number"
+                              min="0"
+                              value={project.designDuration || 0}
+                              onChange={(e) =>
+                                updateProject(
+                                  project.id,
+                                  "designDuration",
+                                  parseInt(e.target.value, 10) || 0
+                                )
+                              }
+                              className="w-20 border border-gray-300 rounded px-2 py-1"
+                            />
+                          </label>
+                          <label className="flex items-center gap-2">
+                            <span className="text-gray-600">C:</span>
+                            <input
+                              type="number"
+                              min="0"
+                              value={project.constructionDuration || 0}
+                              onChange={(e) =>
+                                updateProject(
+                                  project.id,
+                                  "constructionDuration",
+                                  parseInt(e.target.value, 10) || 0
+                                )
+                              }
+                              className="w-20 border border-gray-300 rounded px-2 py-1"
+                            />
+                          </label>
                         </div>
                       </td>
                       <td className="p-4">


### PR DESCRIPTION
## Summary
- replace the static duration labels in the capital projects table with numeric inputs so users can update both design and construction durations
- normalize duration updates to non-negative integers when persisting changes

## Testing
- npm test -- --watchAll=false *(fails: no tests are defined in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68cdb2c50e488329b05e115262ee395c