### PR TITLE
Enforce 1 FTE limit for staff capacities

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -34,6 +34,22 @@ import {
 import { handleCSVImport } from "../utils/dataImport";
 import { useDatabase } from "../hooks/useDatabase";
 
+const MAX_MONTHLY_FTE_HOURS = 2080 / 12;
+const CAPACITY_FIELDS = [
+  "pmCapacity",
+  "designCapacity",
+  "constructionCapacity",
+];
+
+const getNumericValue = (value) => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
 const CapitalPlanningTool = () => {
   // Database hook with fixed default data
   const defaultData = useMemo(
@@ -81,6 +97,7 @@ const CapitalPlanningTool = () => {
   const [activeTab, setActiveTab] = useState("overview");
   const [timeHorizon, setTimeHorizon] = useState(36);
   const [isSaving, setIsSaving] = useState(false);
+  const [categoryCapacityWarnings, setCategoryCapacityWarnings] = useState({});
 
   // Load data from database only once when initialized
   useEffect(() => {
@@ -292,6 +309,7 @@ const CapitalPlanningTool = () => {
     const newCategory = {
       name: "New Category",
       hourlyRate: 65,
+      pmCapacity: 0,
       designCapacity: 40,
       constructionCapacity: 40,
     };
@@ -306,19 +324,82 @@ const CapitalPlanningTool = () => {
   };
 
   const updateStaffCategory = async (id, field, value) => {
-    const updatedCategories = staffCategories.map((c) =>
-      c.id === id ? { ...c, [field]: value } : c
-    );
-    setStaffCategories(updatedCategories);
+    const currentCategory = staffCategories.find((category) => category.id === id);
 
-    // Save to database
-    const updatedCategory = updatedCategories.find((c) => c.id === id);
-    if (updatedCategory) {
-      try {
-        await saveStaffCategory(updatedCategory);
-      } catch (error) {
-        console.error("Error updating staff category:", error);
-      }
+    if (!currentCategory) {
+      return;
+    }
+
+    const isCapacityField = CAPACITY_FIELDS.includes(field);
+    let sanitizedValue;
+
+    if (field === "hourlyRate") {
+      sanitizedValue = Math.max(0, getNumericValue(value));
+    } else if (isCapacityField) {
+      sanitizedValue = Math.max(0, getNumericValue(value));
+    } else {
+      sanitizedValue = value;
+    }
+
+    const updatedCategory = {
+      ...currentCategory,
+      [field]: sanitizedValue,
+    };
+
+    updatedCategory.hourlyRate = getNumericValue(updatedCategory.hourlyRate);
+    CAPACITY_FIELDS.forEach((capacityField) => {
+      updatedCategory[capacityField] = getNumericValue(
+        updatedCategory[capacityField]
+      );
+    });
+
+    const finalTotalHours = CAPACITY_FIELDS.reduce(
+      (sum, capacityField) => sum + updatedCategory[capacityField],
+      0
+    );
+    const remainingCapacity = Math.max(
+      0,
+      MAX_MONTHLY_FTE_HOURS -
+        CAPACITY_FIELDS.reduce((sum, capacityField) => {
+          if (capacityField === field) {
+            return sum;
+          }
+          return sum + getNumericValue(currentCategory[capacityField]);
+        }, 0)
+    );
+
+    if (isCapacityField && finalTotalHours > MAX_MONTHLY_FTE_HOURS) {
+      const fieldLabels = {
+        pmCapacity: "project management",
+        designCapacity: "design",
+        constructionCapacity: "construction",
+      };
+
+      setCategoryCapacityWarnings((prev) => ({
+        ...prev,
+        [id]: `Exceeds the 1 FTE (${MAX_MONTHLY_FTE_HOURS.toFixed(
+          2
+        )} hrs) limit. Only ${remainingCapacity.toFixed(2)} hrs remain for ${
+          fieldLabels[field]
+        } capacity. Reduce other phases or lower this value.`,
+      }));
+      return;
+    }
+
+    setStaffCategories((prev) =>
+      prev.map((category) => (category.id === id ? updatedCategory : category))
+    );
+
+    setCategoryCapacityWarnings((prev) => {
+      const nextWarnings = { ...prev };
+      delete nextWarnings[id];
+      return nextWarnings;
+    });
+
+    try {
+      await saveStaffCategory(updatedCategory);
+    } catch (error) {
+      console.error("Error updating staff category:", error);
     }
   };
 
@@ -326,6 +407,11 @@ const CapitalPlanningTool = () => {
     try {
       await dbDeleteStaffCategory(id);
       setStaffCategories(staffCategories.filter((c) => c.id !== id));
+      setCategoryCapacityWarnings((prev) => {
+        const nextWarnings = { ...prev };
+        delete nextWarnings[id];
+        return nextWarnings;
+      });
     } catch (error) {
       console.error("Error deleting staff category:", error);
     }
@@ -570,14 +656,16 @@ const CapitalPlanningTool = () => {
             />
           )}
 
-          {activeTab === "staff" && (
-            <StaffCategories
-              staffCategories={staffCategories}
-              addStaffCategory={addStaffCategory}
-              updateStaffCategory={updateStaffCategory}
-              deleteStaffCategory={deleteStaffCategory}
-            />
-          )}
+      {activeTab === "staff" && (
+        <StaffCategories
+          staffCategories={staffCategories}
+          addStaffCategory={addStaffCategory}
+          updateStaffCategory={updateStaffCategory}
+          deleteStaffCategory={deleteStaffCategory}
+          capacityWarnings={categoryCapacityWarnings}
+          maxMonthlyFteHours={MAX_MONTHLY_FTE_HOURS}
+        />
+      )}
 
           {activeTab === "allocations" && (
             <StaffAllocations

--- a/src/components/tabs/StaffCategories.js
+++ b/src/components/tabs/StaffCategories.js
@@ -6,6 +6,8 @@ const StaffCategories = ({
   addStaffCategory,
   updateStaffCategory,
   deleteStaffCategory,
+  capacityWarnings = {},
+  maxMonthlyFteHours = 2080 / 12,
 }) => {
   return (
     <div className="bg-white rounded-lg shadow-sm">
@@ -40,95 +42,120 @@ const StaffCategories = ({
                 (category.pmCapacity || 0) +
                 (category.designCapacity || 0) +
                 (category.constructionCapacity || 0);
-              const totalFTE = (totalHours / (2080 / 12)).toFixed(2); // Using correct FTE calculation
+              const totalFTE = (totalHours / maxMonthlyFteHours).toFixed(2);
 
               return (
-                <tr key={category.id} className="border-b border-gray-200">
-                  <td className="p-4">
-                    <input
-                      type="text"
-                      value={category.name}
-                      onChange={(e) =>
-                        updateStaffCategory(category.id, "name", e.target.value)
-                      }
-                      className="w-full border border-gray-300 rounded px-2 py-1"
-                    />
-                  </td>
-                  <td className="p-4">
-                    <input
-                      type="number"
-                      value={category.hourlyRate}
-                      onChange={(e) =>
-                        updateStaffCategory(
-                          category.id,
-                          "hourlyRate",
-                          parseFloat(e.target.value)
-                        )
-                      }
-                      className="w-24 border border-gray-300 rounded px-2 py-1"
-                      min="0"
-                      step="0.01"
-                    />
-                  </td>
-                  <td className="p-4">
-                    <input
-                      type="number"
-                      value={category.pmCapacity || 0}
-                      onChange={(e) =>
-                        updateStaffCategory(
-                          category.id,
-                          "pmCapacity",
-                          parseInt(e.target.value)
-                        )
-                      }
-                      className="w-24 border border-gray-300 rounded px-2 py-1"
-                      min="0"
-                    />
-                  </td>
-                  <td className="p-4">
-                    <input
-                      type="number"
-                      value={category.designCapacity || 0}
-                      onChange={(e) =>
-                        updateStaffCategory(
-                          category.id,
-                          "designCapacity",
-                          parseInt(e.target.value)
-                        )
-                      }
-                      className="w-24 border border-gray-300 rounded px-2 py-1"
-                      min="0"
-                    />
-                  </td>
-                  <td className="p-4">
-                    <input
-                      type="number"
-                      value={category.constructionCapacity || 0}
-                      onChange={(e) =>
-                        updateStaffCategory(
-                          category.id,
-                          "constructionCapacity",
-                          parseInt(e.target.value)
-                        )
-                      }
-                      className="w-24 border border-gray-300 rounded px-2 py-1"
-                      min="0"
-                    />
-                  </td>
-                  <td className="p-4">
-                    <span className="font-medium text-blue-600">
-                      {totalFTE}
-                    </span>
-                  </td>
-                  <td className="p-4">
-                    <button
-                      onClick={() => deleteStaffCategory(category.id)}
-                      className="text-red-600 hover:text-red-800"
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                  </td>
-                </tr>
+                <React.Fragment key={category.id}>
+                  <tr className="border-b border-gray-200">
+                    <td className="p-4">
+                      <input
+                        type="text"
+                        value={category.name}
+                        onChange={(e) =>
+                          updateStaffCategory(
+                            category.id,
+                            "name",
+                            e.target.value
+                          )
+                        }
+                        className="w-full border border-gray-300 rounded px-2 py-1"
+                      />
+                    </td>
+                    <td className="p-4">
+                      <input
+                        type="number"
+                        value={category.hourlyRate}
+                        onChange={(e) =>
+                          updateStaffCategory(
+                            category.id,
+                            "hourlyRate",
+                            parseFloat(e.target.value)
+                          )
+                        }
+                        className="w-24 border border-gray-300 rounded px-2 py-1"
+                        min="0"
+                        step="0.01"
+                      />
+                    </td>
+                    <td className="p-4">
+                      <input
+                        type="number"
+                        value={category.pmCapacity || 0}
+                        onChange={(e) =>
+                          updateStaffCategory(
+                            category.id,
+                            "pmCapacity",
+                            parseFloat(e.target.value)
+                          )
+                        }
+                        className="w-24 border border-gray-300 rounded px-2 py-1"
+                        min="0"
+                        step="0.01"
+                      />
+                    </td>
+                    <td className="p-4">
+                      <input
+                        type="number"
+                        value={category.designCapacity || 0}
+                        onChange={(e) =>
+                          updateStaffCategory(
+                            category.id,
+                            "designCapacity",
+                            parseFloat(e.target.value)
+                          )
+                        }
+                        className="w-24 border border-gray-300 rounded px-2 py-1"
+                        min="0"
+                        step="0.01"
+                      />
+                    </td>
+                    <td className="p-4">
+                      <input
+                        type="number"
+                        value={category.constructionCapacity || 0}
+                        onChange={(e) =>
+                          updateStaffCategory(
+                            category.id,
+                            "constructionCapacity",
+                            parseFloat(e.target.value)
+                          )
+                        }
+                        className="w-24 border border-gray-300 rounded px-2 py-1"
+                        min="0"
+                        step="0.01"
+                      />
+                    </td>
+                    <td className="p-4">
+                      <span
+                        className={`font-medium ${
+                          parseFloat(totalFTE) >= 1
+                            ? "text-red-600"
+                            : "text-blue-600"
+                        }`}
+                      >
+                        {totalFTE}
+                      </span>
+                    </td>
+                    <td className="p-4">
+                      <button
+                        onClick={() => deleteStaffCategory(category.id)}
+                        className="text-red-600 hover:text-red-800"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </td>
+                  </tr>
+                  {capacityWarnings[category.id] && (
+                    <tr className="bg-red-50">
+                      <td
+                        colSpan="7"
+                        className="p-4 text-sm text-red-700 border-b border-gray-200"
+                      >
+                        {capacityWarnings[category.id]}
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               );
             })}
           </tbody>
@@ -156,6 +183,10 @@ const StaffCategories = ({
           <p>
             • <strong>FTE Calculation:</strong> 1 FTE = 173.33 hours/month (2080
             hours/year ÷ 12 months)
+          </p>
+          <p>
+            • <strong>Capacity Limit:</strong> The combined PM, design, and
+            construction capacity for a role cannot exceed 1 FTE per month.
           </p>
           <p>
             • Staff can have capacity across multiple phases based on their role

--- a/src/data/defaultData.js
+++ b/src/data/defaultData.js
@@ -12,8 +12,8 @@ export const defaultStaffCategories = [
     name: "Civil Engineer",
     hourlyRate: 75,
     pmCapacity: 0,
-    designCapacity: 160,
-    constructionCapacity: 40,
+    designCapacity: 139,
+    constructionCapacity: 34,
   },
   {
     id: 3,
@@ -29,7 +29,7 @@ export const defaultStaffCategories = [
     hourlyRate: 80,
     pmCapacity: 40,
     designCapacity: 20,
-    constructionCapacity: 120,
+    constructionCapacity: 113,
   },
   {
     id: 5,


### PR DESCRIPTION
## Summary
- add shared helpers to cap staff capacity edits at 1 FTE and track inline validation warnings
- update the staff categories table to surface remaining capacity, highlight at-limit rows, and show warning messages
- adjust default staff category values and new category defaults so their monthly totals do not exceed 1 FTE

## Testing
- npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68cdb23e7cfc8329a3cd958abff5af0f