### PR TITLE
Fix default data seeding to avoid id collisions

### DIFF
--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -645,24 +645,54 @@ const initializeDatabase = async (defaultData) => {
     ) {
       console.log("Initializing database with default data...");
 
+      const projectTypeIdMap = {};
+      const fundingSourceIdMap = {};
+
       // Insert project types
       for (const type of defaultData.projectTypes || []) {
-        await DatabaseService.saveProjectType(type);
+        const { id: originalId, name, color } = type;
+        const newId = await DatabaseService.saveProjectType({ name, color });
+        if (originalId != null) {
+          projectTypeIdMap[originalId] = newId;
+        }
       }
 
       // Insert funding sources
       for (const source of defaultData.fundingSources || []) {
-        await DatabaseService.saveFundingSource(source);
+        const { id: originalId, name, description } = source;
+        const newId = await DatabaseService.saveFundingSource({
+          name,
+          description,
+        });
+        if (originalId != null) {
+          fundingSourceIdMap[originalId] = newId;
+        }
       }
 
       // Insert staff categories
       for (const category of defaultData.staffCategories || []) {
-        await DatabaseService.saveStaffCategory(category);
+        const { name, hourlyRate, pmCapacity, designCapacity, constructionCapacity } =
+          category;
+        await DatabaseService.saveStaffCategory({
+          name,
+          hourlyRate,
+          pmCapacity,
+          designCapacity,
+          constructionCapacity,
+        });
       }
 
       // Insert projects
       for (const project of defaultData.projects || []) {
-        await DatabaseService.saveProject(project);
+        const { id: _originalId, ...projectData } = project;
+        const mappedProject = {
+          ...projectData,
+          projectTypeId:
+            projectTypeIdMap[project.projectTypeId] ?? project.projectTypeId,
+          fundingSourceId:
+            fundingSourceIdMap[project.fundingSourceId] ?? project.fundingSourceId,
+        };
+        await DatabaseService.saveProject(mappedProject);
       }
 
       console.log("Database initialized successfully");


### PR DESCRIPTION
## Summary
- ensure the initial database seeding inserts default records rather than attempting to update missing ids
- track the generated ids for project types and funding sources so seeded projects reference the correct rows
- prevent duplicated ids that caused edits to affect multiple project types

## Testing
- npm test -- --watchAll=false *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68cdb7ae95b883298cdabb59ce947429