### PR TITLE
Widen name column inputs for readability

### DIFF
--- a/src/components/tabs/PeopleTab.js
+++ b/src/components/tabs/PeopleTab.js
@@ -121,7 +121,7 @@ const PeopleTab = ({
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="p-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  <th className="min-w-[12rem] p-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
                     Name
                   </th>
                   <th className="p-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
@@ -157,7 +157,7 @@ const PeopleTab = ({
 
                   return (
                     <tr key={member.id} className="bg-white hover:bg-gray-50">
-                      <td className="p-3 align-top">
+                      <td className="p-3 align-top min-w-[12rem]">
                         <input
                           type="text"
                           value={member.name || ""}

--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -73,7 +73,7 @@ const ProjectsPrograms = ({
           <table className="w-full">
             <thead className="bg-gray-50">
               <tr>
-                <th className="text-left p-4">Name</th>
+                <th className="text-left p-4 min-w-[16rem]">Name</th>
                 <th className="text-left p-4">Type</th>
                 <th className="text-left p-4">Funding</th>
                 <th className="text-left p-4">Delivery</th>
@@ -97,7 +97,7 @@ const ProjectsPrograms = ({
                   );
                   return (
                     <tr key={project.id} className="border-b border-gray-200">
-                      <td className="p-4">
+                      <td className="p-4 min-w-[16rem]">
                         <input
                           type="text"
                           value={project.name}
@@ -287,7 +287,7 @@ const ProjectsPrograms = ({
           <table className="w-full">
             <thead className="bg-gray-50">
               <tr>
-                <th className="text-left p-4">Program Name</th>
+                <th className="text-left p-4 min-w-[16rem]">Program Name</th>
                 <th className="text-left p-4">Type</th>
                 <th className="text-left p-4">Funding</th>
                 <th className="text-left p-4">Annual Budget</th>
@@ -310,7 +310,7 @@ const ProjectsPrograms = ({
                   );
                   return (
                     <tr key={program.id} className="border-b border-gray-200">
-                      <td className="p-4">
+                      <td className="p-4 min-w-[16rem]">
                         <input
                           type="text"
                           value={program.name}

--- a/src/components/tabs/SettingsTab.js
+++ b/src/components/tabs/SettingsTab.js
@@ -125,7 +125,7 @@ const SettingsTab = ({
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="text-left p-4 font-medium text-gray-900">
+                  <th className="text-left p-4 font-medium text-gray-900 min-w-[16rem]">
                     Funding Source Name
                   </th>
                   <th className="text-left p-4 font-medium text-gray-900">
@@ -147,7 +147,7 @@ const SettingsTab = ({
                       index % 2 === 0 ? "bg-white" : "bg-gray-50"
                     }`}
                   >
-                    <td className="p-4">
+                    <td className="p-4 min-w-[16rem]">
                       <input
                         type="text"
                         value={source.name}

--- a/src/components/tabs/StaffCategories.js
+++ b/src/components/tabs/StaffCategories.js
@@ -25,7 +25,7 @@ const StaffCategories = ({
         <table className="w-full">
           <thead className="bg-gray-50">
             <tr>
-              <th className="text-left p-4">Category Name</th>
+              <th className="text-left p-4 min-w-[14rem]">Category Name</th>
               <th className="text-left p-4">Hourly Rate ($)</th>
               <th className="text-left p-4">PM Capacity (hrs/month)</th>
               <th className="text-left p-4">Design Capacity (hrs/month)</th>
@@ -47,7 +47,7 @@ const StaffCategories = ({
               return (
                 <React.Fragment key={category.id}>
                   <tr className="border-b border-gray-200">
-                    <td className="p-4">
+                    <td className="p-4 min-w-[14rem]">
                       <input
                         type="text"
                         value={category.name}


### PR DESCRIPTION
## Summary
- ensure project and program name columns reserve additional width for easier editing
- widen staff member, staff category, and funding source name fields in their tables to reduce crowding

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cdc4fb1d5083298abd98985aa32dc4