### PR TITLE
Allow setting program PM hours

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -373,6 +373,7 @@ const CapitalPlanningTool = () => {
             annualBudget: 500000,
             designBudgetPercent: 15,
             constructionBudgetPercent: 85,
+            continuousPmHours: 20,
             continuousDesignHours: 40,
             continuousConstructionHours: 80,
             programStartDate: "2025-01-01",

--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -294,7 +294,7 @@ const ProjectsPrograms = ({
                 <th className="text-left p-4">Design %</th>
                 <th className="text-left p-4">Construction %</th>
                 <th className="text-left p-4">Program Period</th>
-                <th className="text-left p-4">Monthly Hours (D/C)</th>
+                <th className="text-left p-4">Monthly Hours (PM/D/C)</th>
                 <th className="text-left p-4">Actions</th>
               </tr>
             </thead>
@@ -436,7 +436,21 @@ const ProjectsPrograms = ({
                         <div className="space-y-1">
                           <input
                             type="number"
-                            value={program.continuousDesignHours}
+                            value={program.continuousPmHours || 0}
+                            onChange={(e) =>
+                              updateProject(
+                                program.id,
+                                "continuousPmHours",
+                                parseInt(e.target.value, 10) || 0
+                              )
+                            }
+                            className="w-16 border border-gray-300 rounded px-1 py-1 text-xs"
+                            placeholder="PM"
+                            min="0"
+                          />
+                          <input
+                            type="number"
+                            value={program.continuousDesignHours || 0}
                             onChange={(e) =>
                               updateProject(
                                 program.id,
@@ -446,10 +460,11 @@ const ProjectsPrograms = ({
                             }
                             className="w-16 border border-gray-300 rounded px-1 py-1 text-xs"
                             placeholder="Design"
+                            min="0"
                           />
                           <input
                             type="number"
-                            value={program.continuousConstructionHours}
+                            value={program.continuousConstructionHours || 0}
                             onChange={(e) =>
                               updateProject(
                                 program.id,
@@ -459,6 +474,7 @@ const ProjectsPrograms = ({
                             }
                             className="w-16 border border-gray-300 rounded px-1 py-1 text-xs"
                             placeholder="Const"
+                            min="0"
                           />
                         </div>
                       </td>
@@ -493,7 +509,8 @@ const ProjectsPrograms = ({
           <p>
             <strong>Required columns for Programs:</strong> Project Name, Type
             (program), Annual Budget, Design %, Construction %, Program Start,
-            Program End
+            Program End. Include optional PM, design, and construction monthly
+            hours to pre-populate staffing needs.
           </p>
           <p>
             <strong>Optional columns:</strong> Priority, Description

--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -68,6 +68,7 @@ const createTables = (database) => {
       annual_budget REAL,
       design_budget_percent REAL,
       construction_budget_percent REAL,
+      continuous_pm_hours INTEGER,
       continuous_design_hours INTEGER,
       continuous_construction_hours INTEGER,
       program_start_date DATE,
@@ -94,6 +95,16 @@ const createTables = (database) => {
   } catch (error) {
     if (!error.message?.includes("duplicate column name")) {
       console.warn("Delivery type migration warning:", error);
+    }
+  }
+
+  try {
+    database.run(
+      "ALTER TABLE projects ADD COLUMN continuous_pm_hours INTEGER DEFAULT 0"
+    );
+  } catch (error) {
+    if (!error.message?.includes("duplicate column name")) {
+      console.warn("Continuous PM hours migration warning:", error);
     }
   }
 
@@ -205,6 +216,7 @@ const DatabaseService = {
             design_duration=?, construction_duration=?,
             design_start_date=?, construction_start_date=?,
             annual_budget=?, design_budget_percent=?, construction_budget_percent=?,
+            continuous_pm_hours=?,
             continuous_design_hours=?, continuous_construction_hours=?,
             program_start_date=?, program_end_date=?,
             priority=?, description=?, delivery_type=?, updated_at=CURRENT_TIMESTAMP
@@ -226,6 +238,7 @@ const DatabaseService = {
           project.annualBudget || null,
           project.designBudgetPercent || null,
           project.constructionBudgetPercent || null,
+          project.continuousPmHours || null,
           project.continuousDesignHours || null,
           project.continuousConstructionHours || null,
           project.programStartDate || null,
@@ -249,10 +262,10 @@ const DatabaseService = {
             design_duration, construction_duration,
             design_start_date, construction_start_date,
             annual_budget, design_budget_percent, construction_budget_percent,
-            continuous_design_hours, continuous_construction_hours,
+            continuous_pm_hours, continuous_design_hours, continuous_construction_hours,
             program_start_date, program_end_date,
             priority, description, delivery_type
-          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         `);
 
         const params = safeBindParams([
@@ -270,6 +283,7 @@ const DatabaseService = {
           project.annualBudget || null,
           project.designBudgetPercent || null,
           project.constructionBudgetPercent || null,
+          project.continuousPmHours || null,
           project.continuousDesignHours || null,
           project.continuousConstructionHours || null,
           project.programStartDate || null,

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -66,6 +66,11 @@ export const handleCSVImport = async (file, projects, setProjects) => {
           annualBudget: parseFloat(row["Annual Budget"] || 0),
           designBudgetPercent: parseFloat(row["Design %"] || 15),
           constructionBudgetPercent: parseFloat(row["Construction %"] || 85),
+          continuousPmHours: parseFloat(row["PM Hours"] || 0) || 0,
+          continuousDesignHours:
+            parseFloat(row["Design Hours"] || row["Design Hrs"] || 0) || 0,
+          continuousConstructionHours:
+            parseFloat(row["Construction Hours"] || row["Construction Hrs"] || 0) || 0,
           programStartDate: row["Program Start"] || "2025-01-01",
           programEndDate: row["Program End"] || "2027-12-31",
         };
@@ -110,6 +115,9 @@ export const downloadCSVTemplate = () => {
       "Priority",
       "Description",
       "Delivery Type",
+      "PM Hours",
+      "Design Hours",
+      "Construction Hours",
     ],
     [
       "Sample Water Main Project",
@@ -124,6 +132,9 @@ export const downloadCSVTemplate = () => {
       "High",
       "Sample project description",
       "self-perform",
+      "",
+      "",
+      "",
     ],
     [
       "Distribution System Annual Program",
@@ -138,6 +149,9 @@ export const downloadCSVTemplate = () => {
       "Medium",
       "Ongoing distribution system improvements",
       "hybrid",
+      "20",
+      "30",
+      "80",
     ],
   ];
 

--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -56,6 +56,27 @@ class CapitalPlanningDB extends Dexie {
             allocation.pmHours = allocation.pmHours || 0;
           });
       });
+
+    this.version(4)
+      .stores({
+        projects:
+          "++id, name, type, projectTypeId, fundingSourceId, deliveryType, totalBudget, designBudget, constructionBudget, designDuration, constructionDuration, designStartDate, constructionStartDate, priority, description, annualBudget, designBudgetPercent, constructionBudgetPercent, continuousPmHours, continuousDesignHours, continuousConstructionHours, programStartDate, programEndDate, createdAt, updatedAt",
+        staffCategories:
+          "++id, name, hourlyRate, designCapacity, constructionCapacity, createdAt, updatedAt",
+        projectTypes: "++id, name, color, createdAt, updatedAt",
+        fundingSources: "++id, name, description, createdAt, updatedAt",
+        staffAllocations:
+          "++id, projectId, categoryId, pmHours, designHours, constructionHours, createdAt, updatedAt",
+        appSettings: "key, value, updatedAt",
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table("projects")
+          .toCollection()
+          .modify((project) => {
+            project.continuousPmHours = project.continuousPmHours || 0;
+          });
+      });
   }
 }
 


### PR DESCRIPTION
## Summary
- add a PM hours input for programs so monthly staffing can include management effort
- persist program PM hours across sql.js and Dexie-backed databases and seed new programs with a default value
- extend CSV import/export guidance to include PM, design, and construction hour columns

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cdd4ac18b48329913a0bbcee0e0f38