### PR TITLE
Fix staff members table initialization for existing databases

### DIFF
--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -167,12 +167,11 @@ const DatabaseService = {
             error
           );
           db = new SQL.Database();
-          createTables(db);
         }
       } else {
         db = new SQL.Database();
-        createTables(db);
       }
+      createTables(db);
     }
     return db;
   },


### PR DESCRIPTION
## Summary
- ensure existing local databases run through the schema creation helper so new tables such as staff_members are present

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cdd541a2a08329b52ecc6b8bcfb065