### PR TITLE
Format staff allocation budgets over one million in millions

### DIFF
--- a/src/components/tabs/StaffAllocations.js
+++ b/src/components/tabs/StaffAllocations.js
@@ -16,6 +16,28 @@ const formatMonthlyFTE = (hours, durationMonths) => {
   return (monthlyHours / HOURS_PER_FTE).toFixed(2);
 };
 
+const formatBudgetAmount = (budget) => {
+  const numericBudget = Number(budget);
+
+  if (!Number.isFinite(numericBudget) || numericBudget === 0) {
+    return "0";
+  }
+
+  if (Math.abs(numericBudget) >= 1_000_000) {
+    const valueInMillions = numericBudget / 1_000_000;
+    const formattedMillions = Number.isInteger(valueInMillions)
+      ? valueInMillions.toString()
+      : valueInMillions.toFixed(1).replace(/\.0$/, "");
+    return `${formattedMillions}M`;
+  }
+
+  if (Math.abs(numericBudget) >= 1_000) {
+    return `${(numericBudget / 1_000).toFixed(0)}K`;
+  }
+
+  return numericBudget.toLocaleString();
+};
+
 const HoursInput = ({ value, onValueChange, durationMonths, label }) => {
   const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
   const [monthlyHours, setMonthlyHours] = useState("");
@@ -267,9 +289,10 @@ const StaffAllocations = ({
               <div>
                 <h3 className="text-lg font-semibold">{project.name}</h3>
                 <p className="text-gray-600">
-                  Design Budget: ${(project.designBudget / 1000).toFixed(0)}K |
-                  Construction Budget: $
-                  {(project.constructionBudget / 1000).toFixed(0)}K
+                  Design Budget: ${formatBudgetAmount(project.designBudget)} |
+                  Construction Budget: ${
+                    formatBudgetAmount(project.constructionBudget)
+                  }
                 </p>
                 <p className="text-sm text-gray-500">
                   Design: {new Date(project.designStartDate).toLocaleDateString()} (


### PR DESCRIPTION
## Summary
- add a formatting helper in the staff allocations tab to render large budgets in millions
- update the budget display so amounts above one million show with an M suffix instead of 1000K

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cddc8031b083299d54d905ec6b8f8e