### PR TITLE
Fix CSV template download handler in ProjectsPrograms

### DIFF
--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Plus,
   Upload,
@@ -501,6 +501,7 @@ const ProjectsPrograms = ({
   projects,
   projectTypes,
   fundingSources,
+  staffCategories,
   addProject,
   updateProject,
   deleteProject,
@@ -532,9 +533,12 @@ const ProjectsPrograms = ({
     }));
   };
 
-  const handleDownloadTemplate = () => {
-    downloadCSVTemplate();
-  };
+  const handleDownloadTemplate = useCallback(() => {
+    const categories = Array.isArray(staffCategories)
+      ? staffCategories
+      : [];
+    downloadCSVTemplate(categories);
+  }, [staffCategories]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- add the missing staffCategories prop to the ProjectsPrograms tab
- memoize the CSV template download handler and pass staff categories to the generator to avoid undefined references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cdecbcd9208329a033548675d5d91b