### PR TITLE
Adjust projects and programs card layout

### DIFF
--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -671,7 +671,7 @@ const ProjectsPrograms = ({
                           {projectCount} {projectCount === 1 ? "project" : "projects"}
                         </span>
                       </div>
-                      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                      <div className="grid gap-6 lg:grid-cols-2">
                         {group.projects.map((project) => (
                           <ProjectCard
                             key={project.id}
@@ -697,7 +697,7 @@ const ProjectsPrograms = ({
                           {programCount} {programCount === 1 ? "program" : "programs"}
                         </span>
                       </div>
-                      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                      <div className="grid gap-6 lg:grid-cols-2">
                         {group.programs.map((program) => (
                           <ProgramCard
                             key={program.id}


### PR DESCRIPTION
## Summary
- limit the project and program card grids to two columns so each card can be wider
- increase spacing between cards to reinforce the wider layout while keeping everything within the viewport

## Testing
- npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68cdeee8774c8329838d47eaa6276930