### PR TITLE
Restructure navigation to group people views

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -6,7 +6,7 @@ This guide documents the application architecture, data model, and analytic meth
 
 - **Frontend stack** – React 18 with functional components and hooks, Tailwind CSS utility classes, Lucide icons, and Recharts data visualizations. The CRA toolchain is customized through `react-app-rewired` and `config-overrides.js` to disable Node-specific polyfills that SQLite does not require.
 - **State orchestration** – `CapitalPlanningTool` centralizes application state, loads default data, synchronizes with the database service, and renders feature tabs.
-- **Tab layout** – Eight tabs encapsulate major workflows: Overview, Projects & Programs, Staff Categories, People, Staff Allocations, Schedule View, Resource Forecast, and Settings.
+- **Tab layout** – Eight primary views anchor the navigation bar: Overview, Projects & Programs, People (with Staff and Categories sub-pages), Effort Projections, Scenarios, Schedule View, Resource Forecast, and Settings.
 
 ## 2. Data persistence layer
 
@@ -36,9 +36,9 @@ Foreign key constraints and unique indices preserve referential integrity betwee
 
 - **Projects & programs** – Inline editable tables allow the planner to change names, types, funding sources, budgets, durations, priorities, and delivery strategies. Buttons add new project or program templates.
 - **CSV import** – `handleCSVImport` maps template headers to project fields, normalizes delivery types (`self-perform`, `hybrid`, `consultant`), assigns default IDs, and captures any `PM/Design/Construction Hours - Category` columns before appending the new records. A downloadable template accelerates adoption.
-- **Staff categories** – Editing capacity or rate fields triggers validation to keep the sum of project management, design, and construction hours at or below one FTE (173.33 monthly hours). Warnings explain when thresholds are exceeded.
-- **People roster** – Planners record per-person availability by phase. Totals aggregate into category-level actual availability and FTE counts, which drive dashboards.
-- **Staff allocations** – For each project-category combination planners enter hours per phase. The screen contextualizes delivery guidance (self-perform vs. hybrid vs. consultant) and flags funding sources that require external coordination.
+- **Categories** – Editing capacity or rate fields triggers validation to keep the sum of project management, design, and construction hours at or below one FTE (173.33 monthly hours). Warnings explain when thresholds are exceeded.
+- **Staff roster** – Planners record per-person availability by phase. Totals aggregate into category-level actual availability and FTE counts, which drive dashboards.
+- **Effort projections** – For each project-category combination planners enter hours per phase. The screen contextualizes delivery guidance (self-perform vs. hybrid vs. consultant) and flags funding sources that require external coordination.
 
 ## 4. Forecasting & analytics methodology
 

--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -12,6 +12,7 @@ import {
   CalendarClock,
   UserCircle,
   GitBranch,
+  ChevronDown,
 } from "lucide-react";
 
 // Import components
@@ -112,6 +113,7 @@ const CapitalPlanningTool = () => {
   const [staffAllocations, setStaffAllocations] = useState({});
   const [staffMembers, setStaffMembers] = useState(defaultStaffMembers);
   const [activeTab, setActiveTab] = useState("overview");
+  const [activeDropdown, setActiveDropdown] = useState(null);
   const [timeHorizon, setTimeHorizon] = useState(36);
   const [scheduleHorizon, setScheduleHorizon] = useState(36);
   const [isSaving, setIsSaving] = useState(false);
@@ -918,16 +920,28 @@ const CapitalPlanningTool = () => {
         <div className="bg-white rounded-lg shadow-sm mb-6">
           <div className="border-b border-gray-200">
             <nav className="flex space-x-8 px-6">
-              {[ 
+              {[
                 { id: "overview", label: "Overview", icon: Calendar },
                 {
                   id: "projects",
                   label: "Projects & Programs",
                   icon: FolderOpen,
                 },
-                { id: "staff", label: "Staff Categories", icon: Users },
-                { id: "people", label: "People", icon: UserCircle },
-                { id: "allocations", label: "Staff Allocations", icon: Edit3 },
+                {
+                  type: "dropdown",
+                  id: "people-menu",
+                  label: "People",
+                  icon: Users,
+                  items: [
+                    { id: "people", label: "Staff", icon: UserCircle },
+                    { id: "staff", label: "Categories", icon: Settings },
+                  ],
+                },
+                {
+                  id: "allocations",
+                  label: "Effort Projections",
+                  icon: Edit3,
+                },
                 { id: "scenarios", label: "Scenarios", icon: GitBranch },
                 {
                   id: "schedule",
@@ -941,6 +955,61 @@ const CapitalPlanningTool = () => {
                 },
                 { id: "settings", label: "Settings", icon: Settings },
               ].map((tab) => {
+                if (tab.type === "dropdown") {
+                  const Icon = tab.icon;
+                  const isActive = tab.items.some((item) => item.id === activeTab);
+                  return (
+                    <div
+                      key={tab.id}
+                      className="relative"
+                      onMouseEnter={() => setActiveDropdown(tab.id)}
+                      onMouseLeave={() => setActiveDropdown(null)}
+                    >
+                      <button
+                        onClick={() =>
+                          setActiveDropdown((current) =>
+                            current === tab.id ? null : tab.id
+                          )
+                        }
+                        className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center gap-2 ${
+                          isActive
+                            ? "border-blue-500 text-blue-600"
+                            : "border-transparent text-gray-500 hover:text-gray-700"
+                        }`}
+                      >
+                        <Icon size={16} />
+                        {tab.label}
+                        <ChevronDown size={14} />
+                      </button>
+                      {activeDropdown === tab.id && (
+                        <div className="absolute left-0 top-full mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10">
+                          {tab.items.map((item) => {
+                            const SubIcon = item.icon;
+                            const isSubActive = activeTab === item.id;
+                            return (
+                              <button
+                                key={item.id}
+                                onClick={() => {
+                                  setActiveTab(item.id);
+                                  setActiveDropdown(null);
+                                }}
+                                className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
+                                  isSubActive
+                                    ? "bg-blue-50 text-blue-600"
+                                    : "text-gray-700 hover:bg-gray-50"
+                                }`}
+                              >
+                                <SubIcon size={16} />
+                                {item.label}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                }
+
                 const Icon = tab.icon;
                 return (
                   <button


### PR DESCRIPTION
## Summary
- replace the People/Staff tabs with a People dropdown that exposes Staff and Categories sub-pages
- rename the Staff Allocations tab to Effort Projections throughout the UI
- update the technical guide to reflect the new navigation structure and terminology

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cdefd31a6083298e6e8f7e015e8cd6