### PR TITLE
Add PDF exports for CIP and staffing gap reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "capital-planning-tool",
       "version": "1.0.0",
       "dependencies": {
+        "@react-pdf/renderer": "^4.3.0",
         "autoprefixer": "^10.4.14",
         "lucide-react": "^0.263.1",
         "postcss": "8.5.6",
@@ -3070,6 +3071,186 @@
         }
       }
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.2.tgz",
+      "integrity": "sha512-/dAWu7Y2RD1RxarDZ9SkYPHgBYOhmcDnet4W/qN/m8k+A2Hr3ja54GymSR7GGxWBtxjKtNauVKrTa9LS1n8WUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^4.0.3",
+        "@react-pdf/types": "^2.9.0",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.3.tgz",
+      "integrity": "sha512-lvP5ryzYM3wpbO9bvqLZYwEr5XBDX9jcaRICvtnoRqdJOo7PRrMnmB4MMScyb+Xw10mGeIubZAAomNAG5ONQZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/png-js": "^3.0.0",
+        "jay-peg": "^1.1.1"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.0.tgz",
+      "integrity": "sha512-Aq+Cc6JYausWLoks2FvHe3PwK9cTuvksB2uJ0AnkKJEUtQbvCq8eCRb1bjbbwIji9OzFRTTzZij7LzkpKHjIeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/image": "^3.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.0",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.0",
+        "emoji-regex": "^10.3.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/layout/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.0.3.tgz",
+      "integrity": "sha512-k+Lsuq8vTwWsCqTp+CCB4+2N+sOTFrzwGA7aw3H9ix/PDWR9QksbmNg0YkzGbLAPI6CeawmiLHcf4trZ5ecLPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^3.0.0",
+        "browserify-zlib": "^0.2.0",
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "linebreak": "^1.1.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/png-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
+      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
+      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-1.1.4.tgz",
+      "integrity": "sha512-oTQDiR/t4Z/Guxac88IavpU2UgN7eR0RMI9DRKvKnvPz2DUasGjXfChAdMqDNmJJxxV26mMy9xQOUV2UU5/okg==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.0.tgz",
+      "integrity": "sha512-MdWfWaqO6d7SZD75TZ2z5L35V+cHpyA43YNRlJNG0RJ7/MeVGDQv12y/BXOJgonZKkeEGdzM3EpAt9/g4E22WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.0",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^1.9.1",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.0.tgz",
+      "integrity": "sha512-28gpA69fU9ZQrDzmd5xMJa1bDf8t0PT3ApUKBl2PUpoE/x4JlvCB5X66nMXrfFrgF2EZrA72zWQAkvbg7TE8zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/font": "^4.0.2",
+        "@react-pdf/layout": "^4.4.0",
+        "@react-pdf/pdfkit": "^4.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/reconciler": "^1.1.4",
+        "@react-pdf/render": "^4.3.0",
+        "@react-pdf/types": "^2.9.0",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.0.tgz",
+      "integrity": "sha512-BGZ2sYNUp38VJUegjva/jsri3iiRGnVNjWI+G9dTwAvLNOmwFvSJzqaCsEnqQ/DW5mrTBk/577FhDY7pv6AidA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.0",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.0.0.tgz",
+      "integrity": "sha512-fDt19KWaJRK/n2AaFoVm31hgGmpygmTV7LsHGJNGZkgzXcFyLsx+XUl63DTDPH3iqxj3xUX128t104GtOz8tTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ckj80vZLlvl9oYrQ4tovEaqKWP3O06Eb1D48/jQWbdwz1Yh7Y9v1cEmwlP8ET+a1Whp8xfdM0xduMexkuPANCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.0"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3416,6 +3597,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -4255,6 +4445,12 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -5119,6 +5315,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -5148,6 +5364,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/big.js": {
@@ -5266,11 +5491,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.26.2",
@@ -5598,6 +5841,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5725,6 +5977,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -5952,6 +6214,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -6707,6 +6975,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -8291,6 +8565,23 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8987,6 +9278,21 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -9194,6 +9500,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.6.tgz",
+      "integrity": "sha512-fXHXcGFTXOvZTSkPJuGOQf5Lv5T/R2itiiCVPg9LxAje5D00O0pP83yJShFq5V89Ly//Gt6acj7z8pbBr34stw==",
+      "license": "ISC"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -9816,6 +10128,12 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -10029,6 +10347,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
       }
     },
     "node_modules/jest": {
@@ -11210,6 +11537,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -11382,6 +11728,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -11682,6 +12034,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
       }
     },
     "node_modules/normalize-url": {
@@ -12028,6 +12389,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -12067,6 +12434,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -13776,6 +14149,15 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14514,6 +14896,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15171,6 +15559,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -15865,6 +16268,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
@@ -16263,6 +16672,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -16608,6 +17023,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
@@ -16616,6 +17041,22 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -16806,6 +17247,20 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -17741,6 +18196,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "@react-pdf/renderer": "^4.3.0",
     "autoprefixer": "^10.4.14",
     "lucide-react": "^0.263.1",
     "postcss": "8.5.6",

--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -1138,6 +1138,7 @@ const CapitalPlanningTool = () => {
               staffCategories={staffCategories}
               staffAllocations={staffAllocations}
               staffingGaps={staffingGaps}
+              resourceForecast={resourceForecast}
             />
           )}
 

--- a/src/components/tabs/ReportsTab.js
+++ b/src/components/tabs/ReportsTab.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { AlertTriangle, BarChart3, DownloadCloud, FileSpreadsheet } from "lucide-react";
 import {
   buildCipEffortReport,
@@ -7,14 +7,16 @@ import {
   downloadReport,
   formatReportMeta,
 } from "../../utils/reports";
+import { downloadPdfDocument } from "../../utils/pdf";
+import CipReportPdf from "../../reports/CipReportPdf";
+import GapAnalysisPdf from "../../reports/GapAnalysisPdf";
 
 const ReportCard = ({
   title,
   description,
   icon: Icon,
   stats = [],
-  buttonLabel,
-  onDownload,
+  actions = [],
 }) => (
   <div className="flex flex-col justify-between rounded-lg border border-gray-100 bg-white p-6 shadow-sm">
     <div>
@@ -42,14 +44,19 @@ const ReportCard = ({
       ) : (
         <p className="text-sm text-gray-500">No summary data available yet.</p>
       )}
-      <button
-        type="button"
-        onClick={onDownload}
-        className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
-      >
-        <DownloadCloud size={16} />
-        {buttonLabel}
-      </button>
+      <div className="flex flex-col gap-2">
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            onClick={action.onClick}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+          >
+            <DownloadCloud size={16} />
+            {action.label}
+          </button>
+        ))}
+      </div>
     </div>
   </div>
 );
@@ -62,6 +69,7 @@ const ReportsTab = ({
   staffCategories,
   staffAllocations,
   staffingGaps,
+  resourceForecast = [],
 }) => {
   const formatCount = (value) => {
     const numeric = Number(value);
@@ -104,6 +112,118 @@ const ReportsTab = ({
     () => formatReportMeta(cipEffortReport),
     [cipEffortReport]
   );
+  const gapMeta = useMemo(() => formatReportMeta(gapReport), [gapReport]);
+
+  const cipPdfFileName = useMemo(
+    () => (cipReport.fileName || `capital_improvement_plan_${Date.now()}.csv`).replace(/\.csv$/i, ".pdf"),
+    [cipReport.fileName]
+  );
+  const gapPdfFileName = useMemo(
+    () => (gapReport.fileName || `staffing_gap_analysis_${Date.now()}.csv`).replace(/\.csv$/i, ".pdf"),
+    [gapReport.fileName]
+  );
+
+  const summarySeries = useMemo(
+    () =>
+      resourceForecast.map((month) => {
+        const totalRequired = staffCategories.reduce(
+          (sum, category) => sum + (month[`${category.name}_required`] || 0),
+          0
+        );
+        const totalActual = staffCategories.reduce(
+          (sum, category) => sum + (month[`${category.name}_actual`] || 0),
+          0
+        );
+
+        return {
+          month: month.month,
+          monthLabel: month.monthLabel,
+          totalRequired: Number(totalRequired.toFixed(2)),
+          totalActual: Number(totalActual.toFixed(2)),
+        };
+      }),
+    [resourceForecast, staffCategories]
+  );
+
+  const categorySeries = useMemo(
+    () =>
+      staffCategories.map((category) => ({
+        id: category.id,
+        name: category.name,
+        data: resourceForecast.map((month) => {
+          const required = Number(month[`${category.name}_required`] || 0);
+          const actual = Number(month[`${category.name}_actual`] || 0);
+          const gap = Math.max(0, required - actual);
+
+          return {
+            month: month.monthLabel,
+            required: Number(required.toFixed(2)),
+            actual: Number(actual.toFixed(2)),
+            gap: Number(gap.toFixed(2)),
+          };
+        }),
+      })),
+    [resourceForecast, staffCategories]
+  );
+
+  const forecastSummary = useMemo(() => {
+    if (summarySeries.length === 0) {
+      return {};
+    }
+
+    const peakMonth = summarySeries.reduce((max, month) =>
+      month.totalRequired > max.totalRequired ? month : max
+    );
+
+    let utilizationSum = 0;
+    let utilizationSamples = 0;
+    summarySeries.forEach((month) => {
+      if (month.totalActual > 0) {
+        utilizationSum += (month.totalRequired / month.totalActual) * 100;
+        utilizationSamples += 1;
+      }
+    });
+
+    return {
+      peakMonth: peakMonth?.monthLabel,
+      averageUtilization:
+        utilizationSamples > 0 ? utilizationSum / utilizationSamples : 0,
+      gapMonths: new Set(staffingGaps.map((gap) => gap.month)).size,
+    };
+  }, [summarySeries, staffingGaps]);
+
+  const handleCipPdfDownload = useCallback(async () => {
+    const documentElement = (
+      <CipReportPdf
+        rows={cipReport.rows}
+        meta={{ ...cipMeta, ...cipReport.meta }}
+        generatedOn={new Date()}
+      />
+    );
+    await downloadPdfDocument(documentElement, cipPdfFileName);
+  }, [cipReport.rows, cipReport.meta, cipMeta, cipPdfFileName]);
+
+  const handleGapPdfDownload = useCallback(async () => {
+    const documentElement = (
+      <GapAnalysisPdf
+        summarySeries={summarySeries}
+        categorySeries={categorySeries}
+        gaps={gapReport.rows}
+        summary={forecastSummary}
+        meta={{ ...gapMeta, ...gapReport.meta }}
+        generatedOn={new Date()}
+      />
+    );
+    await downloadPdfDocument(documentElement, gapPdfFileName);
+  }, [
+    categorySeries,
+    gapMeta,
+    gapPdfFileName,
+    gapReport.rows,
+    gapReport.meta,
+    forecastSummary,
+    summarySeries,
+  ]);
 
   const cipStats = useMemo(() => {
     const stats = [
@@ -200,8 +320,16 @@ const ReportsTab = ({
           description="Portfolio-level export summarizing each project and program with schedule, budget, and delivery details."
           icon={FileSpreadsheet}
           stats={cipStats}
-          buttonLabel="Download CIP CSV"
-          onDownload={() => downloadReport(cipReport)}
+          actions={[
+            {
+              label: "Download CIP CSV",
+              onClick: () => downloadReport(cipReport),
+            },
+            {
+              label: "Download CIP PDF",
+              onClick: handleCipPdfDownload,
+            },
+          ]}
         />
 
         <ReportCard
@@ -209,8 +337,12 @@ const ReportsTab = ({
           description="Detailed view of planned hours, FTE, and costs for every project-category combination to support resource planning."
           icon={BarChart3}
           stats={cipEffortStats}
-          buttonLabel="Download Effort CSV"
-          onDownload={() => downloadReport(cipEffortReport)}
+          actions={[
+            {
+              label: "Download Effort CSV",
+              onClick: () => downloadReport(cipEffortReport),
+            },
+          ]}
         />
 
         <ReportCard
@@ -218,8 +350,16 @@ const ReportsTab = ({
           description="Month-by-month shortage report highlighting where demand exceeds available staffing capacity."
           icon={AlertTriangle}
           stats={gapStats}
-          buttonLabel="Download Gap CSV"
-          onDownload={() => downloadReport(gapReport)}
+          actions={[
+            {
+              label: "Download Gap CSV",
+              onClick: () => downloadReport(gapReport),
+            },
+            {
+              label: "Download Gap PDF",
+              onClick: handleGapPdfDownload,
+            },
+          ]}
         />
       </div>
     </div>

--- a/src/reports/CipReportPdf.js
+++ b/src/reports/CipReportPdf.js
@@ -1,0 +1,207 @@
+import React from "react";
+import { Document, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+
+const COLUMN_DEFINITIONS = [
+  { key: "id", label: "Project ID", flex: 0.8 },
+  { key: "name", label: "Project / Program", flex: 1.8 },
+  { key: "type", label: "Type", flex: 0.6 },
+  { key: "projectType", label: "Project Type", flex: 1.1 },
+  { key: "fundingSource", label: "Funding Source", flex: 1.1 },
+  { key: "deliveryMethod", label: "Delivery Method", flex: 0.9 },
+  { key: "designStart", label: "Design Start", flex: 0.8 },
+  { key: "constructionStart", label: "Construction Start", flex: 0.9 },
+  { key: "constructionEnd", label: "Construction End", flex: 0.9 },
+  { key: "totalBudget", label: "Total Budget", flex: 0.9 },
+  { key: "annualBudget", label: "Annual Budget", flex: 0.8 },
+  { key: "priority", label: "Priority", flex: 0.6 },
+];
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 36,
+    fontSize: 9,
+    fontFamily: "Helvetica",
+    color: "#111827",
+    backgroundColor: "#ffffff",
+  },
+  header: {
+    marginBottom: 18,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 700,
+    color: "#1f2937",
+  },
+  subtitle: {
+    fontSize: 12,
+    color: "#4b5563",
+    marginTop: 6,
+  },
+  metaRow: {
+    flexDirection: "row",
+    marginTop: 12,
+    flexWrap: "wrap",
+  },
+  metaItem: {
+    marginRight: 16,
+    marginBottom: 6,
+  },
+  metaLabel: {
+    fontSize: 9,
+    color: "#6b7280",
+  },
+  metaValue: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: "#111827",
+  },
+  tableContainer: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  tableHeader: {
+    flexDirection: "row",
+    backgroundColor: "#111827",
+    color: "#ffffff",
+  },
+  headerCell: {
+    paddingVertical: 6,
+    paddingHorizontal: 6,
+    fontSize: 9,
+    fontWeight: 600,
+  },
+  tableRow: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
+    borderBottomColor: "#e5e7eb",
+    minHeight: 20,
+    alignItems: "center",
+  },
+  tableRowAlt: {
+    backgroundColor: "#f9fafb",
+  },
+  cell: {
+    paddingVertical: 5,
+    paddingHorizontal: 6,
+    fontSize: 9,
+  },
+  pageNumber: {
+    position: "absolute",
+    fontSize: 9,
+    bottom: 24,
+    right: 36,
+    color: "#6b7280",
+  },
+});
+
+const formatDateLabel = (value) => {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch (error) {
+    return value;
+  }
+};
+
+const getCellStyle = (column) => ({
+  flexGrow: column.flex,
+  flexShrink: column.flex,
+  flexBasis: 0,
+});
+
+const renderMetaValue = (label, value) => (
+  <View key={label} style={styles.metaItem}>
+    <Text style={styles.metaLabel}>{label}</Text>
+    <Text style={styles.metaValue}>{value}</Text>
+  </View>
+);
+
+const CipReportPdf = ({ rows = [], meta = {}, generatedOn = new Date() }) => {
+  const generatedLabel = formatDateLabel(generatedOn);
+  const totalProjects = meta.projectCount || 0;
+  const totalPrograms = meta.programCount || 0;
+
+  return (
+    <Document>
+      <Page size="TABLOID" orientation="landscape" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Capital Improvement Plan Report</Text>
+          <Text style={styles.subtitle}>
+            Comprehensive list of CIP projects and programs with delivery timeline and budget context.
+          </Text>
+          <View style={styles.metaRow}>
+            {renderMetaValue("Generated", generatedLabel)}
+            {renderMetaValue("Projects", totalProjects)}
+            {renderMetaValue("Programs", totalPrograms)}
+            {meta.totalProjectBudgetLabel
+              ? renderMetaValue("Total Project Budget", meta.totalProjectBudgetLabel)
+              : null}
+            {meta.totalProgramBudgetLabel
+              ? renderMetaValue("Annual Program Budget", meta.totalProgramBudgetLabel)
+              : null}
+          </View>
+        </View>
+
+        <View style={styles.tableContainer}>
+          <View style={styles.tableHeader}>
+            {COLUMN_DEFINITIONS.map((column) => (
+              <View
+                key={column.key}
+                style={{ ...getCellStyle(column), ...styles.headerCell }}
+              >
+                <Text>{column.label}</Text>
+              </View>
+            ))}
+          </View>
+
+          {rows.length > 0 ? (
+            rows.map((row, index) => (
+              <View
+                key={`${row.id || row.name || "row"}-${index}`}
+                style={[
+                  styles.tableRow,
+                  index % 2 === 1 ? styles.tableRowAlt : null,
+                ]}
+              >
+                {COLUMN_DEFINITIONS.map((column) => (
+                  <View key={column.key} style={{ ...getCellStyle(column), ...styles.cell }}>
+                    <Text>
+                      {row[column.key] != null ? String(row[column.key]) : ""}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ))
+          ) : (
+            <View style={styles.tableRow}>
+              <View style={{ flex: 1, padding: 12 }}>
+                <Text>No project data available.</Text>
+              </View>
+            </View>
+          )}
+        </View>
+
+        <Text
+          style={styles.pageNumber}
+          render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`}
+          fixed
+        />
+      </Page>
+    </Document>
+  );
+};
+
+export default CipReportPdf;

--- a/src/reports/GapAnalysisPdf.js
+++ b/src/reports/GapAnalysisPdf.js
@@ -1,0 +1,687 @@
+import React from "react";
+import {
+  Document,
+  Page,
+  StyleSheet,
+  Text,
+  View,
+  Svg,
+} from "@react-pdf/renderer";
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 36,
+    fontSize: 9,
+    fontFamily: "Helvetica",
+    color: "#111827",
+    backgroundColor: "#ffffff",
+  },
+  header: {
+    marginBottom: 18,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 700,
+    color: "#1f2937",
+  },
+  subtitle: {
+    fontSize: 12,
+    color: "#4b5563",
+    marginTop: 6,
+  },
+  metaRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginTop: 12,
+  },
+  metaItem: {
+    marginRight: 16,
+    marginBottom: 6,
+  },
+  metaLabel: {
+    fontSize: 9,
+    color: "#6b7280",
+  },
+  metaValue: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: "#111827",
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: "#1f2937",
+    marginBottom: 12,
+  },
+  chartCard: {
+    borderWidth: 1,
+    borderColor: "#e5e7eb",
+    borderRadius: 8,
+    padding: 12,
+    backgroundColor: "#ffffff",
+  },
+  legend: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginTop: 10,
+  },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginRight: 16,
+    marginTop: 4,
+  },
+  legendSwatch: {
+    width: 12,
+    height: 4,
+    marginRight: 6,
+  },
+  chartGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginHorizontal: -8,
+  },
+  chartWrapper: {
+    width: "50%",
+    paddingHorizontal: 8,
+    marginBottom: 16,
+  },
+  tableContainer: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  tableHeaderRow: {
+    flexDirection: "row",
+    backgroundColor: "#111827",
+    color: "#ffffff",
+  },
+  tableHeaderCell: {
+    paddingVertical: 6,
+    paddingHorizontal: 6,
+    fontSize: 9,
+    fontWeight: 600,
+  },
+  tableRow: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
+    borderBottomColor: "#e5e7eb",
+  },
+  tableRowAlt: {
+    backgroundColor: "#f9fafb",
+  },
+  tableCell: {
+    paddingVertical: 5,
+    paddingHorizontal: 6,
+    fontSize: 9,
+  },
+  tableEmpty: {
+    padding: 12,
+  },
+  pageNumber: {
+    position: "absolute",
+    fontSize: 9,
+    bottom: 24,
+    right: 36,
+    color: "#6b7280",
+  },
+});
+
+const GAP_COLUMNS = [
+  { key: "monthLabel", label: "Month", flex: 1 },
+  { key: "category", label: "Staff Category", flex: 1.4 },
+  { key: "required", label: "Allocated (FTE)", flex: 1 },
+  { key: "available", label: "Actual (FTE)", flex: 1 },
+  { key: "gap", label: "Gap (FTE)", flex: 0.9 },
+  { key: "severity", label: "Severity", flex: 0.8 },
+];
+
+const formatNumber = (value, digits = 1) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return "0";
+  }
+  return numeric.toFixed(digits);
+};
+
+const formatPercent = (value, digits = 1) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return "0%";
+  }
+  return `${numeric.toFixed(digits)}%`;
+};
+
+const formatDateLabel = (value) => {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch (error) {
+    return value;
+  }
+};
+
+const Legend = ({ items = [] }) => (
+  <View style={styles.legend}>
+    {items.map((item) => (
+      <View key={item.label} style={styles.legendItem}>
+        <View
+          style={{
+            ...styles.legendSwatch,
+            backgroundColor: item.color,
+          }}
+        />
+        <Text>{item.label}</Text>
+      </View>
+    ))}
+  </View>
+);
+
+const getXPosition = (index, length, chartWidth, paddingLeft) => {
+  if (length <= 1) {
+    return paddingLeft + chartWidth / 2;
+  }
+
+  return paddingLeft + (index / (length - 1)) * chartWidth;
+};
+
+const getYPosition = (value, maxValue, chartHeight, paddingTop) => {
+  const safeMax = Math.max(1, maxValue);
+  const safeValue = Math.max(0, Number(value) || 0);
+  const normalized = safeValue / safeMax;
+  return paddingTop + chartHeight - normalized * chartHeight;
+};
+
+const SummaryChart = ({ data = [] }) => {
+  if (!data.length) {
+    return <Text>No forecast data available.</Text>;
+  }
+
+  const width = 720;
+  const height = 260;
+  const paddingLeft = 60;
+  const paddingRight = 24;
+  const paddingTop = 24;
+  const paddingBottom = 36;
+  const chartWidth = width - paddingLeft - paddingRight;
+  const chartHeight = height - paddingTop - paddingBottom;
+
+  const maxValue = Math.max(
+    1,
+    ...data.map((point) => Math.max(point.totalRequired || 0, point.totalActual || 0))
+  );
+
+  const yTicks = 4;
+  const xLabelCount = Math.min(6, data.length);
+  const xInterval = Math.max(1, Math.floor(data.length / xLabelCount));
+
+  const buildLinePoints = (key) =>
+    data
+      .map((point, index) => {
+        const x = getXPosition(index, data.length, chartWidth, paddingLeft);
+        const y = getYPosition(
+          point[key] || 0,
+          maxValue,
+          chartHeight,
+          paddingTop
+        );
+        return `${x},${y}`;
+      })
+      .join(" ");
+
+  return (
+    <View style={styles.chartCard}>
+      <Svg width={width} height={height}>
+        {/* Axes */}
+        <Svg.Line
+          x1={paddingLeft}
+          y1={paddingTop}
+          x2={paddingLeft}
+          y2={paddingTop + chartHeight}
+          stroke="#9ca3af"
+          strokeWidth={1}
+        />
+        <Svg.Line
+          x1={paddingLeft}
+          y1={paddingTop + chartHeight}
+          x2={paddingLeft + chartWidth}
+          y2={paddingTop + chartHeight}
+          stroke="#9ca3af"
+          strokeWidth={1}
+        />
+
+        {/* Horizontal grid lines */}
+        {Array.from({ length: yTicks + 1 }).map((_, index) => {
+          const value = (maxValue / yTicks) * index;
+          const y = getYPosition(value, maxValue, chartHeight, paddingTop);
+          return (
+            <React.Fragment key={`y-${index}`}>
+              <Svg.Line
+                x1={paddingLeft}
+                y1={y}
+                x2={paddingLeft + chartWidth}
+                y2={y}
+                stroke="#e5e7eb"
+                strokeWidth={0.6}
+              />
+              <Svg.Text
+                x={paddingLeft - 6}
+                y={y + 3}
+                fontSize={8}
+                fill="#6b7280"
+                textAnchor="end"
+              >
+                {formatNumber(value, 0)}
+              </Svg.Text>
+            </React.Fragment>
+          );
+        })}
+
+        {/* X axis labels */}
+        {data.map((point, index) => {
+          if (index % xInterval !== 0 && index !== data.length - 1) {
+            return null;
+          }
+          const x = getXPosition(index, data.length, chartWidth, paddingLeft);
+          return (
+            <Svg.Text
+              key={`x-${index}`}
+              x={x}
+              y={paddingTop + chartHeight + 16}
+              fontSize={8}
+              fill="#6b7280"
+              textAnchor="middle"
+            >
+              {point.monthLabel}
+            </Svg.Text>
+          );
+        })}
+
+        {/* Data lines */}
+        <Svg.Polyline
+          points={buildLinePoints("totalRequired")}
+          fill="none"
+          stroke="#2563eb"
+          strokeWidth={2}
+        />
+        <Svg.Polyline
+          points={buildLinePoints("totalActual")}
+          fill="none"
+          stroke="#10b981"
+          strokeWidth={2}
+          strokeDasharray="6 3"
+        />
+      </Svg>
+      <Legend
+        items={[
+          { label: "Allocated (FTE)", color: "#2563eb" },
+          { label: "Actual Availability (FTE)", color: "#10b981" },
+        ]}
+      />
+    </View>
+  );
+};
+
+const CategoryChart = ({ name, data = [] }) => {
+  if (!data.length) {
+    return (
+      <View style={styles.chartCard}>
+        <Text>{name}</Text>
+        <Text>No forecast data available.</Text>
+      </View>
+    );
+  }
+
+  const width = 520;
+  const height = 220;
+  const paddingLeft = 46;
+  const paddingRight = 18;
+  const paddingTop = 20;
+  const paddingBottom = 34;
+  const chartWidth = width - paddingLeft - paddingRight;
+  const chartHeight = height - paddingTop - paddingBottom;
+
+  const maxValue = Math.max(
+    1,
+    ...data.map((point) => Math.max(point.required || 0, point.actual || 0))
+  );
+
+  const xLabelCount = Math.min(4, data.length);
+  const xInterval = Math.max(1, Math.floor(data.length / xLabelCount));
+
+  const buildLinePoints = (key) =>
+    data
+      .map((point, index) => {
+        const x = getXPosition(index, data.length, chartWidth, paddingLeft);
+        const y = getYPosition(
+          point[key] || 0,
+          maxValue,
+          chartHeight,
+          paddingTop
+        );
+        return `${x},${y}`;
+      })
+      .join(" ");
+
+  const actualAreaPoints = [
+    `${paddingLeft},${paddingTop + chartHeight}`,
+    ...data.map((point, index) => {
+      const x = getXPosition(index, data.length, chartWidth, paddingLeft);
+      const y = getYPosition(
+        point.actual || 0,
+        maxValue,
+        chartHeight,
+        paddingTop
+      );
+      return `${x},${y}`;
+    }),
+    `${paddingLeft + chartWidth},${paddingTop + chartHeight}`,
+  ].join(" ");
+
+  const gapRects = data
+    .map((point, index) => {
+      const gapValue = Math.max(0, Number(point.gap) || 0);
+      if (gapValue <= 0) {
+        return null;
+      }
+      const requiredY = getYPosition(
+        Number(point.required) || 0,
+        maxValue,
+        chartHeight,
+        paddingTop
+      );
+      const actualY = getYPosition(
+        (Number(point.required) || 0) - gapValue,
+        maxValue,
+        chartHeight,
+        paddingTop
+      );
+      if (actualY <= requiredY) {
+        return null;
+      }
+      const columnWidth = chartWidth / Math.max(1, data.length);
+      const barWidth = columnWidth * 0.6;
+      const barX =
+        paddingLeft + index * columnWidth + (columnWidth - barWidth) / 2;
+      return {
+        x: barX,
+        y: requiredY,
+        width: barWidth,
+        height: actualY - requiredY,
+      };
+    })
+    .filter(Boolean);
+
+  return (
+    <View style={styles.chartCard}>
+      <Text style={{ fontSize: 11, fontWeight: 600, marginBottom: 8 }}>{name}</Text>
+      <Svg width={width} height={height}>
+        {/* Axes */}
+        <Svg.Line
+          x1={paddingLeft}
+          y1={paddingTop}
+          x2={paddingLeft}
+          y2={paddingTop + chartHeight}
+          stroke="#9ca3af"
+          strokeWidth={1}
+        />
+        <Svg.Line
+          x1={paddingLeft}
+          y1={paddingTop + chartHeight}
+          x2={paddingLeft + chartWidth}
+          y2={paddingTop + chartHeight}
+          stroke="#9ca3af"
+          strokeWidth={1}
+        />
+
+        {/* Horizontal grid */}
+        {Array.from({ length: 4 }).map((_, index) => {
+          const value = (maxValue / 3) * index;
+          const y = getYPosition(value, maxValue, chartHeight, paddingTop);
+          return (
+            <React.Fragment key={`cat-y-${index}`}>
+              <Svg.Line
+                x1={paddingLeft}
+                y1={y}
+                x2={paddingLeft + chartWidth}
+                y2={y}
+                stroke="#e5e7eb"
+                strokeWidth={0.6}
+              />
+              <Svg.Text
+                x={paddingLeft - 6}
+                y={y + 3}
+                fontSize={8}
+                fill="#6b7280"
+                textAnchor="end"
+              >
+                {formatNumber(value, 0)}
+              </Svg.Text>
+            </React.Fragment>
+          );
+        })}
+
+        {/* X axis labels */}
+        {data.map((point, index) => {
+          if (index % xInterval !== 0 && index !== data.length - 1) {
+            return null;
+          }
+          const x = getXPosition(index, data.length, chartWidth, paddingLeft);
+          return (
+            <Svg.Text
+              key={`cat-x-${index}`}
+              x={x}
+              y={paddingTop + chartHeight + 16}
+              fontSize={8}
+              fill="#6b7280"
+              textAnchor="middle"
+            >
+              {point.month}
+            </Svg.Text>
+          );
+        })}
+
+        {/* Actual area */}
+        <Svg.Polygon
+          points={actualAreaPoints}
+          fill="#10b981"
+          fillOpacity={0.18}
+        />
+
+        {/* Gap bars */}
+        {gapRects.map((rect, index) => (
+          <Svg.Rect
+            key={`gap-${index}`}
+            x={rect.x}
+            y={rect.y}
+            width={rect.width}
+            height={rect.height}
+            fill="#ef4444"
+            fillOpacity={0.35}
+          />
+        ))}
+
+        {/* Lines */}
+        <Svg.Polyline
+          points={buildLinePoints("required")}
+          fill="none"
+          stroke="#2563eb"
+          strokeWidth={2}
+        />
+        <Svg.Polyline
+          points={buildLinePoints("actual")}
+          fill="none"
+          stroke="#10b981"
+          strokeWidth={2}
+        />
+      </Svg>
+      <Legend
+        items={[
+          { label: "Allocated (FTE)", color: "#2563eb" },
+          { label: "Actual Availability", color: "#10b981" },
+          { label: "Gap (FTE)", color: "#ef4444" },
+        ]}
+      />
+    </View>
+  );
+};
+
+const GapTable = ({ rows = [] }) => (
+  <View style={styles.tableContainer}>
+    <View style={styles.tableHeaderRow}>
+      {GAP_COLUMNS.map((column) => (
+        <View
+          key={column.key}
+          style={{
+            flexGrow: column.flex,
+            flexShrink: column.flex,
+            flexBasis: 0,
+            ...styles.tableHeaderCell,
+          }}
+        >
+          <Text>{column.label}</Text>
+        </View>
+      ))}
+    </View>
+
+    {rows.length > 0 ? (
+      rows.map((row, index) => (
+        <View
+          key={`${row.month}-${row.category}-${index}`}
+          style={[
+            styles.tableRow,
+            index % 2 === 1 ? styles.tableRowAlt : null,
+          ]}
+        >
+          {GAP_COLUMNS.map((column) => (
+            <View
+              key={column.key}
+              style={{
+                flexGrow: column.flex,
+                flexShrink: column.flex,
+                flexBasis: 0,
+                ...styles.tableCell,
+              }}
+            >
+              <Text>
+                {row[column.key] != null ? String(row[column.key]) : ""}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ))
+    ) : (
+      <View style={styles.tableRow}>
+        <View style={styles.tableEmpty}>
+          <Text>No staffing gap entries are currently available.</Text>
+        </View>
+      </View>
+    )}
+  </View>
+);
+
+const GapAnalysisPdf = ({
+  summarySeries = [],
+  categorySeries = [],
+  gaps = [],
+  summary = {},
+  meta = {},
+  generatedOn = new Date(),
+}) => {
+  const generatedLabel = formatDateLabel(generatedOn);
+
+  return (
+    <Document>
+      <Page size="TABLOID" orientation="landscape" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Staffing Gap Analysis</Text>
+          <Text style={styles.subtitle}>
+            Resource forecast overview highlighting allocation versus availability and critical staffing gaps.
+          </Text>
+          <View style={styles.metaRow}>
+            <View style={styles.metaItem}>
+              <Text style={styles.metaLabel}>Generated</Text>
+              <Text style={styles.metaValue}>{generatedLabel}</Text>
+            </View>
+            <View style={styles.metaItem}>
+              <Text style={styles.metaLabel}>Gap Entries</Text>
+              <Text style={styles.metaValue}>{meta.gapCount || 0}</Text>
+            </View>
+            <View style={styles.metaItem}>
+              <Text style={styles.metaLabel}>Critical Gaps</Text>
+              <Text style={styles.metaValue}>{meta.criticalCount || 0}</Text>
+            </View>
+            {summary?.peakMonth ? (
+              <View style={styles.metaItem}>
+                <Text style={styles.metaLabel}>Peak Demand Month</Text>
+                <Text style={styles.metaValue}>{summary.peakMonth}</Text>
+              </View>
+            ) : null}
+            {summary?.averageUtilization ? (
+              <View style={styles.metaItem}>
+                <Text style={styles.metaLabel}>Avg. Utilization</Text>
+                <Text style={styles.metaValue}>
+                  {formatPercent(summary.averageUtilization, 1)}
+                </Text>
+              </View>
+            ) : null}
+            {summary?.gapMonths ? (
+              <View style={styles.metaItem}>
+                <Text style={styles.metaLabel}>Months with Gaps</Text>
+                <Text style={styles.metaValue}>{summary.gapMonths}</Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Portfolio Staffing Outlook</Text>
+          <SummaryChart data={summarySeries} />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Category Detail</Text>
+          <View style={styles.chartGrid}>
+            {categorySeries.length > 0 ? (
+              categorySeries.map((category) => (
+                <View key={category.name} style={styles.chartWrapper}>
+                  <CategoryChart name={category.name} data={category.data} />
+                </View>
+              ))
+            ) : (
+              <Text>No staff categories available.</Text>
+            )}
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Detailed Staffing Gap Entries</Text>
+          <GapTable rows={gaps} />
+        </View>
+
+        <Text
+          style={styles.pageNumber}
+          render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`}
+          fixed
+        />
+      </Page>
+    </Document>
+  );
+};
+
+export default GapAnalysisPdf;

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,0 +1,22 @@
+import { pdf } from "@react-pdf/renderer";
+
+export const downloadPdfDocument = async (documentElement, fileName) => {
+  if (!documentElement) {
+    console.warn("No PDF document element provided for download");
+    return;
+  }
+
+  try {
+    const blob = await pdf(documentElement).toBlob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = fileName || `report_${Date.now()}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error("Failed to generate PDF document", error);
+  }
+};


### PR DESCRIPTION
## Summary
- add the @react-pdf/renderer dependency and a helper for triggering PDF downloads
- build tabloid landscape CIP and staffing gap PDF documents and expose download actions from the report cards
- wire resource forecast data into the reports tab so the gap PDF can mirror the on-screen charts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cdfa6ec3f48329abc7681a7e13dc59