### PR TITLE
Replace header text with centered Vector logo

### DIFF
--- a/src/assets/vector-logo.svg
+++ b/src/assets/vector-logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200" role="img" aria-labelledby="title desc">
+  <title id="title">Vector logo</title>
+  <desc id="desc">Stylized Vector logomark with upward arrow and motion accents</desc>
+  <g fill="none" stroke="#111827" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M118 78 L206 32 L248 112 L196 100 L180 148 Z" fill="#fff" />
+    <path d="M118 78 L206 32 L248 112" />
+    <path d="M196 100 L180 148" />
+    <path d="M88 108 L148 68" />
+    <path d="M72 134 L132 94" />
+    <path d="M62 158 L110 128" />
+    <circle cx="88" cy="108" r="6" fill="#111827" stroke="none" />
+    <circle cx="62" cy="158" r="6" fill="#111827" stroke="none" />
+    <circle cx="132" cy="94" r="6" fill="#111827" stroke="none" />
+  </g>
+  <text x="40" y="180" font-family="'Montserrat', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="60" fill="#111827">VECTOR</text>
+</svg>

--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -43,6 +43,7 @@ import {
 } from "../utils/calculations";
 import { handleCSVImport } from "../utils/dataImport";
 import { useDatabase } from "../hooks/useDatabase";
+import vectorLogo from "../assets/vector-logo.svg";
 
 const MAX_MONTHLY_FTE_HOURS = 2080 / 12;
 const CAPACITY_FIELDS = [
@@ -926,18 +927,20 @@ const CapitalPlanningTool = () => {
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
-          <div className="flex justify-between items-center">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 mb-2">Vector</h1>
-              <p className="text-gray-600">CIP and Resource Planning</p>
+        <div className="bg-white rounded-lg shadow-sm p-6 mb-6 relative">
+          {isSaving && (
+            <div className="absolute top-6 right-6 flex items-center gap-2 text-blue-600">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+              <span className="text-sm">Saving...</span>
             </div>
-            {isSaving && (
-              <div className="flex items-center gap-2 text-blue-600">
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
-                <span className="text-sm">Saving...</span>
-              </div>
-            )}
+          )}
+          <div className="flex flex-col items-center text-center">
+            <img
+              src={vectorLogo}
+              alt="Vector logo"
+              className="h-20 w-auto mb-3"
+            />
+            <p className="text-gray-600">CIP and Resource Planning</p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- replace the header title with the Vector logomark asset and center the tagline beneath it
- preserve the saving indicator by positioning it in the card corner
- add a reusable SVG version of the Vector logo for the application header

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68ce143dad48832992f9f3d315471393