### PR TITLE
Use provided public logo asset

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -926,18 +926,20 @@ const CapitalPlanningTool = () => {
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
-          <div className="flex justify-between items-center">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 mb-2">Vector</h1>
-              <p className="text-gray-600">CIP and Resource Planning</p>
+        <div className="bg-white rounded-lg shadow-sm p-6 mb-6 relative">
+          {isSaving && (
+            <div className="absolute top-6 right-6 flex items-center gap-2 text-blue-600">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+              <span className="text-sm">Saving...</span>
             </div>
-            {isSaving && (
-              <div className="flex items-center gap-2 text-blue-600">
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
-                <span className="text-sm">Saving...</span>
-              </div>
-            )}
+          )}
+          <div className="flex flex-col items-center text-center">
+            <img
+              src={`${process.env.PUBLIC_URL}/logo.png`}
+              alt="Vector logo"
+              className="h-20 w-auto mb-3"
+            />
+            <p className="text-gray-600">CIP and Resource Planning</p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- update the capital planning header to load the provided /public/logo.png asset via PUBLIC_URL
- keep the tagline centered beneath the image while removing the previous custom asset import

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68ce143dad48832992f9f3d315471393