### PR TITLE
Fix StaffAllocations read-only prop missing

### DIFF
--- a/src/components/tabs/StaffAllocations.js
+++ b/src/components/tabs/StaffAllocations.js
@@ -241,6 +241,7 @@ const StaffAllocations = ({
   staffAllocations,
   updateStaffAllocation,
   fundingSources = [],
+  isReadOnly = false,
 }) => {
   const deliveryGuidance = {
     "self-perform": {


### PR DESCRIPTION
## Summary
- accept an `isReadOnly` flag in the StaffAllocations tab component with a default of `false` so the control can respect read-only mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cf563d9ca883298a47c1341468d463