### PR TITLE
Adjust application header layout

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -70,24 +70,8 @@ const getNumericValue = (value) => {
 };
 
 const CapitalPlanningTool = () => {
-  const {
-    activeOrganization,
-    activeOrganizationId,
-    activeMembership,
-    canEditActiveOrg,
-    memberships = [],
-    setActiveOrganizationId,
-    signOut,
-    user,
-  } = useAuth();
+  const { canEditActiveOrg } = useAuth();
   const isReadOnly = !canEditActiveOrg;
-  const organizationLabel =
-    activeOrganization?.name || "Select an organization";
-  const roleDescription = activeMembership?.isSuperuser
-    ? "Superuser access"
-    : canEditActiveOrg
-    ? "Editor access"
-    : "Viewer access";
 
   // Database hook with fixed default data
   const defaultData = useMemo(
@@ -1218,81 +1202,14 @@ const CapitalPlanningTool = () => {
   return (
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-7xl mx-auto">
-        {/* Header */}
-        <div className="bg-white rounded-lg shadow-sm px-4 py-4 mb-6 relative">
+        {/* Navigation Tabs */}
+        <div className="bg-white rounded-lg shadow-sm mb-6 relative">
           {isSaving && (
             <div className="absolute top-4 right-4 flex items-center gap-2 text-blue-600">
               <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
               <span className="text-sm">Saving...</span>
             </div>
           )}
-          <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-            <div className="flex items-center gap-3">
-              <img
-                src={`${process.env.PUBLIC_URL}/logo.png`}
-                alt="Vector logo"
-                className="h-12 w-auto"
-              />
-              <div>
-                <p className="text-sm font-semibold text-gray-900">Vector</p>
-                <p className="text-xs uppercase tracking-wide text-gray-500">
-                  Capital & Resource Planning
-                </p>
-              </div>
-            </div>
-            <div className="text-center xl:flex-1">
-              <h1 className="text-lg font-semibold text-gray-900">
-                {organizationLabel}
-              </h1>
-            </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:flex-wrap text-sm">
-              <div className="flex flex-col min-w-[200px]">
-                <label
-                  htmlFor="app-organization-selector"
-                  className="text-xs font-semibold uppercase text-gray-400 tracking-wide"
-                >
-                  Organization
-                </label>
-                <select
-                  id="app-organization-selector"
-                  className="mt-1 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-70"
-                  value={activeOrganizationId ?? ""}
-                  onChange={(event) => setActiveOrganizationId(event.target.value)}
-                  disabled={!memberships.length}
-                >
-                  {memberships.length ? (
-                    memberships.map((membership) => (
-                      <option
-                        key={membership.id}
-                        value={membership.organizationId ?? ""}
-                      >
-                        {membership.organization?.name || "Untitled Organization"}
-                      </option>
-                    ))
-                  ) : (
-                    <option value="">No organizations available</option>
-                  )}
-                </select>
-              </div>
-              <div className="text-left sm:text-right">
-                <p className="text-sm font-medium text-gray-900">
-                  {user?.email || "Signed in"}
-                </p>
-                <p className="text-xs text-gray-500">{roleDescription}</p>
-              </div>
-              <button
-                type="button"
-                onClick={signOut}
-                className="inline-flex items-center justify-center rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-600 shadow-sm transition-colors hover:bg-gray-50"
-              >
-                Sign out
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Navigation Tabs */}
-        <div className="bg-white rounded-lg shadow-sm mb-6">
           <div className="border-b border-gray-200">
             <nav className="flex space-x-8 px-6">
               {[

--- a/src/components/auth/AuthGate.js
+++ b/src/components/auth/AuthGate.js
@@ -7,7 +7,7 @@ const AuthGate = ({ children }) => {
   const {
     authLoading,
     session,
-    memberships,
+    memberships = [],
     activeOrganizationId,
     setActiveOrganizationId,
     activeOrganization,
@@ -16,6 +16,14 @@ const AuthGate = ({ children }) => {
     user,
     signOut,
   } = useAuth();
+
+  const organizationLabel =
+    activeOrganization?.name || 'Select an organization';
+  const roleDescription = activeMembership?.isSuperuser
+    ? 'Superuser access'
+    : canEditActiveOrg
+    ? 'Editor access'
+    : 'Viewer access';
 
   if (authLoading) {
     return (
@@ -38,50 +46,72 @@ const AuthGate = ({ children }) => {
 
   return (
     <div className="min-h-screen bg-slate-100 flex flex-col">
-      <header className="bg-white border-b border-slate-200 shadow-sm">
-        <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-4 gap-4">
-          <div>
-            <h1 className="text-lg font-semibold text-slate-900">Vector</h1>
-            <p className="text-xs text-slate-500 uppercase tracking-wide">Capital Planning</p>
-          </div>
-          <div className="flex flex-1 items-center justify-end gap-4 flex-wrap">
-            <div className="flex flex-col text-left min-w-[200px]">
-              <label
-                htmlFor="organization-selector"
-                className="text-xs font-semibold uppercase text-slate-400 tracking-wide"
-              >
-                Organization
-              </label>
-              <select
-                id="organization-selector"
-                className="mt-1 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                value={activeOrganizationId ?? ''}
-                onChange={(event) => setActiveOrganizationId(event.target.value)}
-              >
-                {memberships.map((membership) => (
-                  <option key={membership.id} value={membership.organizationId}>
-                    {membership.organization?.name || 'Untitled Organization'}
-                  </option>
-                ))}
-              </select>
+      <header className="bg-slate-100">
+        <div className="mx-auto w-full max-w-7xl px-6 py-4">
+          <div className="bg-white rounded-lg shadow-sm px-4 py-4">
+            <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+              <div className="flex items-center gap-3">
+                <img
+                  src={`${process.env.PUBLIC_URL}/logo.png`}
+                  alt="Vector logo"
+                  className="h-12 w-auto"
+                />
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Vector</p>
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
+                    Capital &amp; Resource Planning
+                  </p>
+                </div>
+              </div>
+              <div className="text-center xl:flex-1">
+                <h1 className="text-lg font-semibold text-gray-900">
+                  {organizationLabel}
+                </h1>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:flex-wrap text-sm">
+                <div className="flex flex-col min-w-[200px]">
+                  <label
+                    htmlFor="app-organization-selector"
+                    className="text-xs font-semibold uppercase text-gray-400 tracking-wide"
+                  >
+                    Organization
+                  </label>
+                  <select
+                    id="app-organization-selector"
+                    className="mt-1 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-70"
+                    value={activeOrganizationId ?? ''}
+                    onChange={(event) => setActiveOrganizationId(event.target.value)}
+                    disabled={!memberships.length}
+                  >
+                    {memberships.length ? (
+                      memberships.map((membership) => (
+                        <option
+                          key={membership.id}
+                          value={membership.organizationId ?? ''}
+                        >
+                          {membership.organization?.name || 'Untitled Organization'}
+                        </option>
+                      ))
+                    ) : (
+                      <option value="">No organizations available</option>
+                    )}
+                  </select>
+                </div>
+                <div className="text-left sm:text-right">
+                  <p className="text-sm font-medium text-gray-900">
+                    {user?.email || 'Signed in'}
+                  </p>
+                  <p className="text-xs text-gray-500">{roleDescription}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={signOut}
+                  className="inline-flex items-center justify-center rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-600 shadow-sm transition-colors hover:bg-gray-50"
+                >
+                  Sign out
+                </button>
+              </div>
             </div>
-            <div className="text-right">
-              <p className="text-sm font-medium text-slate-700">{user?.email}</p>
-              <p className="text-xs text-slate-400">
-                {activeMembership?.isSuperuser
-                  ? 'Superuser access'
-                  : canEditActiveOrg
-                    ? 'Editor access'
-                    : 'Viewer access'}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={signOut}
-              className="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm hover:bg-slate-50"
-            >
-              Sign out
-            </button>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- restyle the in-app header to use a compact flex layout with the logo and new Capital & Resource Planning subtitle
- surface the active organization name alongside organization switching, user details, and sign-out controls inside the main header
- derive organization and role labels from the auth context to keep the header informative without extra height

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cf5b5155848329ac81ec7d0a2648dd