### PR TITLE
Fix admin membership listing and clarify edit permissions

### DIFF
--- a/src/components/admin/SuperuserAdminPanel.js
+++ b/src/components/admin/SuperuserAdminPanel.js
@@ -41,7 +41,6 @@ const SuperuserAdminPanel = ({ onClose }) => {
   const [addMemberForm, setAddMemberForm] = useState({
     email: '',
     role: 'viewer',
-    makeEditor: false,
   });
   const [isCreatingOrg, setIsCreatingOrg] = useState(false);
   const [isUpdatingOrg, setIsUpdatingOrg] = useState(false);
@@ -366,11 +365,16 @@ const SuperuserAdminPanel = ({ onClose }) => {
     setIsAddingMember(true);
 
     try {
+      const makeEditor =
+        addMemberForm.role === 'editor' ||
+        addMemberForm.role === 'admin' ||
+        addMemberForm.role === 'superuser';
+
       const { error } = await supabase.rpc('superuser_add_user_to_organization', {
         target_email: addMemberForm.email,
         org_id: selectedOrgId,
         member_role: addMemberForm.role,
-        make_editor: addMemberForm.makeEditor,
+        make_editor: makeEditor,
       });
 
       if (error) {
@@ -378,7 +382,7 @@ const SuperuserAdminPanel = ({ onClose }) => {
       }
 
       showFeedback('success', 'Member access updated.');
-      setAddMemberForm({ email: '', role: 'viewer', makeEditor: false });
+      setAddMemberForm({ email: '', role: 'viewer' });
       await Promise.all([loadMembers(selectedOrgId), refreshMemberships()]);
     } catch (error) {
       console.error('Unable to add member', error);
@@ -784,20 +788,9 @@ const SuperuserAdminPanel = ({ onClose }) => {
                     </select>
                   </div>
                 </div>
-                <label className="inline-flex items-center gap-2 text-xs text-slate-600">
-                  <input
-                    type="checkbox"
-                    checked={addMemberForm.makeEditor}
-                    onChange={(event) =>
-                      setAddMemberForm((previous) => ({
-                        ...previous,
-                        makeEditor: event.target.checked,
-                      }))
-                    }
-                    className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  Grant edit permissions
-                </label>
+                <p className="text-xs text-slate-500">
+                  Editing permissions are granted automatically to editors, admins, and superusers.
+                </p>
                 <button
                   type="submit"
                   disabled={isAddingMember}

--- a/supabase/migrations/20241002000000_organization_join_requests.sql
+++ b/supabase/migrations/20241002000000_organization_join_requests.sql
@@ -116,11 +116,11 @@ begin
 
   return query
   select
-    m.id as membership_id,
-    m.organization_id,
-    m.user_id,
-    u.email,
-    coalesce(u.raw_user_meta_data->>'full_name', '') as full_name,
+    m.id::uuid as membership_id,
+    m.organization_id::uuid,
+    m.user_id::uuid,
+    coalesce(u.email::text, ''::text) as email,
+    coalesce((u.raw_user_meta_data->>'full_name')::text, ''::text) as full_name,
     m.role,
     m.can_edit,
     m.created_at,
@@ -227,8 +227,8 @@ begin
     r.organization_id,
     o.name as organization_name,
     r.user_id,
-    u.email,
-    coalesce(u.raw_user_meta_data->>'full_name', '') as full_name,
+    coalesce(u.email::text, ''::text) as email,
+    coalesce((u.raw_user_meta_data->>'full_name')::text, ''::text) as full_name,
     r.status,
     r.created_at,
     r.updated_at,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -320,11 +320,11 @@ begin
 
   return query
   select
-    m.id as membership_id,
-    m.organization_id,
-    m.user_id,
-    u.email,
-    coalesce(u.raw_user_meta_data->>'full_name', '') as full_name,
+    m.id::uuid as membership_id,
+    m.organization_id::uuid,
+    m.user_id::uuid,
+    coalesce(u.email::text, ''::text) as email,
+    coalesce((u.raw_user_meta_data->>'full_name')::text, ''::text) as full_name,
     m.role,
     m.can_edit,
     m.created_at,
@@ -431,8 +431,8 @@ begin
     r.organization_id,
     o.name as organization_name,
     r.user_id,
-    u.email,
-    coalesce(u.raw_user_meta_data->>'full_name', '') as full_name,
+    coalesce(u.email::text, ''::text) as email,
+    coalesce((u.raw_user_meta_data->>'full_name')::text, ''::text) as full_name,
     r.status,
     r.created_at,
     r.updated_at,


### PR DESCRIPTION
## Summary
- fix the superuser membership RPC to cast email and full name outputs so the function result type matches what PostgREST expects
- apply the same explicit typing to the superuser join request RPC
- remove the redundant manual "grant edit" toggle and derive editor access directly from the selected role in the admin panel UI

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cf67f4c494832995ddfdc439e35098