### PR TITLE
Auto-add superusers to new organizations

### DIFF
--- a/supabase/migrations/20241015000000_auto_add_superusers_to_organizations.sql
+++ b/supabase/migrations/20241015000000_auto_add_superusers_to_organizations.sql
@@ -1,0 +1,33 @@
+-- Automatically add existing superusers to new organizations
+
+create or replace function public.add_superusers_to_new_organization()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.memberships (organization_id, user_id, role, can_edit)
+  select
+    new.id,
+    superusers.user_id,
+    'superuser'::public.organization_role,
+    true
+  from (
+    select distinct m.user_id
+    from public.memberships m
+    where m.role::text = 'superuser'
+  ) as superusers
+  on conflict (organization_id, user_id) do update
+    set role = 'superuser',
+        can_edit = true,
+        updated_at = timezone('utc', now());
+
+  return new;
+end;
+$$;
+
+drop trigger if exists organizations_add_superusers on public.organizations;
+create trigger organizations_add_superusers
+after insert on public.organizations
+for each row execute function public.add_superusers_to_new_organization();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -193,6 +193,38 @@ create trigger organizations_set_updated_at
 before update on public.organizations
 for each row execute function public.set_updated_at();
 
+create or replace function public.add_superusers_to_new_organization()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.memberships (organization_id, user_id, role, can_edit)
+  select
+    new.id,
+    superusers.user_id,
+    'superuser'::public.organization_role,
+    true
+  from (
+    select distinct m.user_id
+    from public.memberships m
+    where m.role::text = 'superuser'
+  ) as superusers
+  on conflict (organization_id, user_id) do update
+    set role = 'superuser',
+        can_edit = true,
+        updated_at = timezone('utc', now());
+
+  return new;
+end;
+$$;
+
+drop trigger if exists organizations_add_superusers on public.organizations;
+create trigger organizations_add_superusers
+after insert on public.organizations
+for each row execute function public.add_superusers_to_new_organization();
+
 drop trigger if exists memberships_set_updated_at on public.memberships;
 create trigger memberships_set_updated_at
 before update on public.memberships


### PR DESCRIPTION
## Summary
- add a trigger function that inserts existing superusers into newly created organizations
- update the schema snapshot to include the trigger

## Testing
- not run (SQL change only)


------
https://chatgpt.com/codex/tasks/task_b_68cf6e9282a48329bdd4f7089c993a91