### PR TITLE
Fix default annual program hours when no staffing is configured

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -459,9 +459,9 @@ const CapitalPlanningTool = () => {
             annualBudget: 500000,
             designBudgetPercent: 15,
             constructionBudgetPercent: 85,
-            continuousPmHours: 20,
-            continuousDesignHours: 40,
-            continuousConstructionHours: 80,
+            continuousPmHours: 0,
+            continuousDesignHours: 0,
+            continuousConstructionHours: 0,
             description: "",
           };
 

--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -1199,6 +1199,9 @@ const ProjectsPrograms = ({
         } else {
           updateProject(previous.programId, {
             continuousHoursByCategory: null,
+            continuousPmHours: 0,
+            continuousDesignHours: 0,
+            continuousConstructionHours: 0,
           });
         }
       }
@@ -1216,6 +1219,9 @@ const ProjectsPrograms = ({
       if (previous.programId != null) {
         updateProject(previous.programId, {
           continuousHoursByCategory: null,
+          continuousPmHours: 0,
+          continuousDesignHours: 0,
+          continuousConstructionHours: 0,
         });
       }
 


### PR DESCRIPTION
## Summary
- set the default continuous hours for new annual programs to zero so summaries start empty
- reset program continuous hour totals to zero when staff category settings are cleared

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cf71ddbae08329a25bbfe5e58c9c2e