### PR TITLE
Support staff assignments for annual programs

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -28,6 +28,7 @@ import PeopleTab from "./tabs/PeopleTab";
 import ScenariosTab from "./tabs/ScenariosTab";
 import ReportsTab from "./tabs/ReportsTab";
 import StaffAssignmentsTab from "./tabs/StaffAssignmentsTab";
+import { isProjectOrProgram } from "../utils/projectTypes.js";
 
 // Import data and utilities
 import {
@@ -1415,7 +1416,9 @@ const CapitalPlanningTool = () => {
 
           {activeTab === "assignments" && (
             <StaffAssignmentsTab
-              projects={projects.filter((project) => project.type === "project")}
+              projects={projects.filter((project) =>
+                isProjectOrProgram(project)
+              )}
               staffMembers={staffMembers}
               staffCategories={staffCategories}
               staffAllocations={staffAllocations}

--- a/src/components/tabs/StaffAssignmentsTab.js
+++ b/src/components/tabs/StaffAssignmentsTab.js
@@ -6,6 +6,10 @@ import {
   Info,
   RefreshCw,
 } from "lucide-react";
+import {
+  getProjectTypeDisplayLabel,
+  isProjectOrProgram,
+} from "../../utils/projectTypes.js";
 
 const formatHours = (value) => {
   const numeric = Number(value);
@@ -91,11 +95,7 @@ const StaffAssignmentsTab = ({
       assignmentPlan.monthlyDemandByProjectCategory || {};
 
     return projects
-      .filter(
-        (project) =>
-          project &&
-          (project.type === "project" || project.type === "program")
-      )
+      .filter((project) => project && isProjectOrProgram(project))
       .map((project) => {
         const projectId = Number(project.id);
         const projectAllocations = staffAllocations[projectId] || {};
@@ -431,10 +431,7 @@ const StaffAssignmentsTab = ({
           const isExpanded = expandedProjects[entry.projectId] ?? true;
           const summary = entry.summary || {};
           const hasUnfilled = Number(summary?.unfilled?.totalHours || 0) > 0;
-          const projectTypeLabel =
-            entry.project.type === "program"
-              ? "Annual Program"
-              : "Capital Project";
+          const projectTypeLabel = getProjectTypeDisplayLabel(entry.project);
           const projectMonthlyDemand = Number(entry.monthlyDemandTotal || 0);
 
           return (

--- a/src/utils/projectTypes.js
+++ b/src/utils/projectTypes.js
@@ -1,0 +1,49 @@
+const extractTypeValue = (input) => {
+  if (input && typeof input === "object" && "type" in input) {
+    return input.type;
+  }
+
+  return input;
+};
+
+const normalizeTypeString = (value) => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  return String(value).trim().toLowerCase();
+};
+
+const collapseTypeString = (input) =>
+  normalizeTypeString(extractTypeValue(input)).replace(/[\s_-]+/g, "");
+
+const containsKeyword = (collapsed, keyword) =>
+  typeof collapsed === "string" && collapsed.includes(keyword);
+
+export const isProgramProject = (projectOrType) => {
+  const collapsed = collapseTypeString(projectOrType);
+  if (!collapsed) {
+    return false;
+  }
+
+  return containsKeyword(collapsed, "program");
+};
+
+export const isCapitalProject = (projectOrType) => {
+  const collapsed = collapseTypeString(projectOrType);
+  if (!collapsed) {
+    return true;
+  }
+
+  if (containsKeyword(collapsed, "program")) {
+    return false;
+  }
+
+  return containsKeyword(collapsed, "project") || !collapsed;
+};
+
+export const isProjectOrProgram = (projectOrType) =>
+  isCapitalProject(projectOrType) || isProgramProject(projectOrType);
+
+export const getProjectTypeDisplayLabel = (projectOrType) =>
+  isProgramProject(projectOrType) ? "Annual Program" : "Capital Project";

--- a/src/utils/staffAssignments.js
+++ b/src/utils/staffAssignments.js
@@ -1,3 +1,5 @@
+import { isCapitalProject, isProgramProject } from "./projectTypes.js";
+
 const toNumber = (value) => {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : 0;
@@ -91,12 +93,12 @@ const buildProjectPhaseDurationMap = (projects = []) => {
       return;
     }
 
-    if (project.type === "program") {
+    if (isProgramProject(project)) {
       map.set(Number(project.id), getProgramPhaseDurations(project));
       return;
     }
 
-    if (project.type === "project") {
+    if (isCapitalProject(project)) {
       map.set(Number(project.id), getProjectPhaseDurations(project));
     }
   });
@@ -366,7 +368,7 @@ const buildProgramDemandMaps = (projects = [], staffCategories = []) => {
   const monthly = {};
 
   (projects || []).forEach((project) => {
-    if (!project || project.id == null || project.type !== "program") {
+    if (!project || project.id == null || !isProgramProject(project)) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- add project type helpers to consistently classify capital projects vs annual programs
- update staff assignment planning to use the flexible project classification so annual programs contribute demand and durations
- align the staff assignment UI with the new helpers so annual programs appear with the correct label
- pass eligible programs to the staff assignments tab so program assignments can be reviewed and overridden alongside projects

## Testing
- npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68cf713d154883299bc116b25bab752d