### PR TITLE
Collapse project groups by default

### DIFF
--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -1118,7 +1118,7 @@ const ProjectsPrograms = ({
       const nextState = { ...previous };
       projectGroups.forEach((group) => {
         if (nextState[group.key] === undefined) {
-          nextState[group.key] = true;
+          nextState[group.key] = false;
         }
       });
       return nextState;

--- a/src/components/tabs/StaffAllocations.js
+++ b/src/components/tabs/StaffAllocations.js
@@ -317,7 +317,7 @@ const StaffAllocations = ({
       const nextState = { ...previous };
       projectGroups.forEach((group) => {
         if (nextState[group.key] === undefined) {
-          nextState[group.key] = true;
+          nextState[group.key] = false;
         }
       });
       return nextState;


### PR DESCRIPTION
## Summary
- default grouped project sections to start collapsed on the Projects & Programs tab
- apply the same default collapsed behavior to grouped effort projections

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cf761970ec83299942a1be2e33f618