### PR TITLE
Add budget percentage controls for projects

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -48,6 +48,7 @@ import { handleCSVImport } from "../utils/dataImport";
 import { useDatabase } from "../hooks/useDatabase";
 import { useAuth } from "../context/AuthContext";
 import { buildStaffAssignmentPlan } from "../utils/staffAssignments";
+import { normalizeProjectBudgetBreakdown } from "../utils/projectBudgets";
 
 const MAX_MONTHLY_FTE_HOURS = 2080 / 12;
 const CAPACITY_FIELDS = [
@@ -77,7 +78,7 @@ const CapitalPlanningTool = () => {
   // Database hook with fixed default data
   const defaultData = useMemo(
     () => ({
-      projects: defaultProjects,
+      projects: defaultProjects.map(normalizeProjectBudgetBreakdown),
       staffCategories: defaultStaffCategories,
       projectTypes: defaultProjectTypes,
       fundingSources: defaultFundingSources,
@@ -122,7 +123,9 @@ const CapitalPlanningTool = () => {
   );
   const [projectTypes, setProjectTypes] = useState(defaultProjectTypes);
   const [fundingSources, setFundingSources] = useState(defaultFundingSources);
-  const [projects, setProjects] = useState(defaultProjects);
+  const [projects, setProjects] = useState(() =>
+    defaultProjects.map(normalizeProjectBudgetBreakdown)
+  );
   const [staffAllocations, setStaffAllocations] = useState({});
   const [staffMembers, setStaffMembers] = useState(defaultStaffMembers);
   const [staffAssignmentOverrides, setStaffAssignmentOverrides] = useState({});
@@ -171,10 +174,12 @@ const CapitalPlanningTool = () => {
           // Only update if we got actual data
           if (projectsData && projectsData.length > 0) {
             setProjects(
-              projectsData.map((project) => ({
-                ...project,
-                deliveryType: project.deliveryType || "self-perform",
-              }))
+              projectsData.map((project) =>
+                normalizeProjectBudgetBreakdown({
+                  ...project,
+                  deliveryType: project.deliveryType || "self-perform",
+                })
+              )
             );
           }
           if (staffCategoriesData && staffCategoriesData.length > 0) {
@@ -442,8 +447,8 @@ const CapitalPlanningTool = () => {
             fundingSourceId: fundingSources[0]?.id || 1,
             deliveryType: "self-perform",
             totalBudget: 1000000,
-            designBudget: 100000,
-            constructionBudget: 900000,
+            designBudgetPercent: 15,
+            constructionBudgetPercent: 85,
             designDuration: 3,
             constructionDuration: 12,
             designStartDate: "2025-01-01",
@@ -466,9 +471,11 @@ const CapitalPlanningTool = () => {
             description: "",
           };
 
+    const normalizedProject = normalizeProjectBudgetBreakdown(newProject);
+
     try {
-      const savedProjectId = await saveProject(newProject);
-      const projectWithId = { ...newProject, id: savedProjectId };
+      const savedProjectId = await saveProject(normalizedProject);
+      const projectWithId = { ...normalizedProject, id: savedProjectId };
       setProjects((prev) => [...prev, projectWithId]);
     } catch (error) {
       console.error("Error adding project:", error);
@@ -498,7 +505,9 @@ const CapitalPlanningTool = () => {
           };
 
     const updatedProjects = projects.map((p) =>
-      p.id === id ? { ...p, ...updates } : p
+      p.id === id
+        ? normalizeProjectBudgetBreakdown({ ...p, ...updates })
+        : p
     );
     setProjects(updatedProjects);
 

--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -283,6 +283,21 @@ const ProjectCard = ({
     updateProject(project.id, field, Number.isNaN(parsed) ? 0 : parsed);
   };
 
+  const handleFloatChange = (field) => (event) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const { value } = event.target;
+    if (value === "") {
+      updateProject(project.id, field, null);
+      return;
+    }
+
+    const parsed = parseFloat(value);
+    updateProject(project.id, field, Number.isNaN(parsed) ? 0 : parsed);
+  };
+
   const handleSelectOption = (field, options = []) => (event) => {
     if (isReadOnly) {
       return;
@@ -457,6 +472,30 @@ const ProjectCard = ({
             min="0"
             value={project.totalBudget || ""}
             onChange={handleNumberChange("totalBudget")}
+            className={projectInputClass}
+            disabled={isReadOnly}
+          />
+        </Field>
+
+        <Field label="Design budget (%)">
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={project.designBudgetPercent ?? ""}
+            onChange={handleFloatChange("designBudgetPercent")}
+            className={projectInputClass}
+            disabled={isReadOnly}
+          />
+        </Field>
+
+        <Field label="Construction budget (%)">
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={project.constructionBudgetPercent ?? ""}
+            onChange={handleFloatChange("constructionBudgetPercent")}
             className={projectInputClass}
             disabled={isReadOnly}
           />

--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../context/AuthContext';
+import { normalizeProjectBudgetBreakdown } from '../utils/projectBudgets';
 
 const toCamelCaseKey = (key) =>
   key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
@@ -81,7 +82,7 @@ const projectFromRow = (row) => {
     camel.continuousHoursByCategory,
     {}
   );
-  return camel;
+  return normalizeProjectBudgetBreakdown(camel);
 };
 
 const projectToRow = (project, organizationId) => ({

--- a/src/utils/projectBudgets.js
+++ b/src/utils/projectBudgets.js
@@ -1,0 +1,93 @@
+const parseNumeric = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const clampPercent = (value) => {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 100) {
+    return 100;
+  }
+
+  return value;
+};
+
+const roundTo = (value, precision = 2) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+export const normalizeProjectBudgetBreakdown = (project) => {
+  if (!project || project.type !== "project") {
+    return project;
+  }
+
+  const result = { ...project };
+
+  const totalBudget = parseNumeric(project.totalBudget);
+  const existingDesignBudget = parseNumeric(project.designBudget);
+  const existingConstructionBudget = parseNumeric(project.constructionBudget);
+  let designPercent = parseNumeric(project.designBudgetPercent);
+  let constructionPercent = parseNumeric(project.constructionBudgetPercent);
+
+  if (
+    totalBudget !== null &&
+    totalBudget !== 0 &&
+    !Number.isFinite(designPercent) &&
+    Number.isFinite(existingDesignBudget)
+  ) {
+    designPercent = (existingDesignBudget / totalBudget) * 100;
+  }
+
+  if (
+    totalBudget !== null &&
+    totalBudget !== 0 &&
+    !Number.isFinite(constructionPercent) &&
+    Number.isFinite(existingConstructionBudget)
+  ) {
+    constructionPercent = (existingConstructionBudget / totalBudget) * 100;
+  }
+
+  if (Number.isFinite(designPercent)) {
+    const normalizedPercent = roundTo(clampPercent(designPercent));
+    result.designBudgetPercent = normalizedPercent;
+
+    if (Number.isFinite(totalBudget)) {
+      result.designBudget = Math.round(
+        (totalBudget * normalizedPercent) / 100
+      );
+    }
+  } else if (Number.isFinite(existingDesignBudget)) {
+    result.designBudget = Math.round(existingDesignBudget);
+  }
+
+  if (Number.isFinite(constructionPercent)) {
+    const normalizedPercent = roundTo(clampPercent(constructionPercent));
+    result.constructionBudgetPercent = normalizedPercent;
+
+    if (Number.isFinite(totalBudget)) {
+      result.constructionBudget = Math.round(
+        (totalBudget * normalizedPercent) / 100
+      );
+    }
+  } else if (Number.isFinite(existingConstructionBudget)) {
+    result.constructionBudget = Math.round(existingConstructionBudget);
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Summary
- normalize project budget allocations whenever data is loaded, created, or updated so percentages drive design and construction amounts
- expose design and construction budget percentage inputs on project cards
- add a reusable helper for budget normalization and apply it during CSV import and database hydration

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cf7826f18c83299b73c3333d344d75