### PR TITLE
Extend staffing gap forecast to five years

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -163,7 +163,7 @@ const CapitalPlanningTool = () => {
   const [activeTab, setActiveTab] = useState("overview");
   const [activeDropdown, setActiveDropdown] = useState(null);
   const dropdownRefs = useRef({});
-  const [timeHorizon, setTimeHorizon] = useState(36);
+  const [timeHorizon, setTimeHorizon] = useState(60);
   const [scheduleHorizon, setScheduleHorizon] = useState(36);
   const [isSaving, setIsSaving] = useState(false);
   const [categoryCapacityWarnings, setCategoryCapacityWarnings] = useState({});

--- a/src/components/tabs/ResourceForecast.js
+++ b/src/components/tabs/ResourceForecast.js
@@ -125,7 +125,7 @@ const ResourceForecast = ({
             <input
               type="number"
               value={timeHorizon}
-              onChange={(e) => setTimeHorizon(parseInt(e.target.value, 10) || 36)}
+              onChange={(e) => setTimeHorizon(parseInt(e.target.value, 10) || 60)}
               className="w-16 border border-gray-300 rounded px-2 py-1"
               min="12"
               max="60"

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -180,7 +180,7 @@ const generateForecastFromDate = (
   staffAvailabilityByCategory = {}
 ) => {
   const forecast = [];
-  const safeTimeHorizon = Math.max(1, Math.min(timeHorizon || 36, 120)); // Limit to reasonable range
+  const safeTimeHorizon = Math.max(1, Math.min(timeHorizon || 60, 120)); // Limit to reasonable range
 
   const hasExplicitAvailability =
     staffAvailabilityByCategory &&
@@ -479,7 +479,7 @@ export const generateScenarioForecastDetails = (
     return { forecast: [], monthDetails: {}, startDate: new Date() };
   }
 
-  const safeTimeHorizon = Math.max(1, Math.min(timeHorizon || 36, 120));
+  const safeTimeHorizon = Math.max(1, Math.min(timeHorizon || 60, 120));
   const startDate = getScenarioStartDate(projectTimelines);
   const forecast = [];
   const monthDetails = {};
@@ -1187,7 +1187,7 @@ export const analyzeScenario = (
   staffAllocations,
   staffCategories,
   staffAvailabilityByCategory = {},
-  timeHorizon = 36
+  timeHorizon = 60
 ) => {
   const scenarioProjects = applyScenarioAdjustments(
     baselineProjects,


### PR DESCRIPTION
## Summary
- default the staffing forecast horizon to 60 months so charts show five-year coverage
- adjust resource and scenario forecast calculations to fall back to a 60-month window
- ensure gap analysis views honor the extended default horizon

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68d0cb8d4a8c8329b0da36c198b6c86f