### PR TITLE
Add project effort template management and project size field

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -38,6 +38,7 @@ import {
   defaultProjects,
   defaultStaffMembers,
   defaultStaffAssignments,
+  defaultProjectEffortTemplates,
 } from "../data/defaultData";
 import {
   calculateTimelines,
@@ -49,6 +50,7 @@ import { useDatabase } from "../hooks/useDatabase";
 import { useAuth } from "../context/AuthContext";
 import { buildStaffAssignmentPlan } from "../utils/staffAssignments";
 import { normalizeProjectBudgetBreakdown } from "../utils/projectBudgets";
+import { normalizeEffortTemplate } from "../utils/projectEffortTemplates";
 
 const MAX_MONTHLY_FTE_HOURS = 2080 / 12;
 const CAPACITY_FIELDS = [
@@ -116,6 +118,9 @@ const CapitalPlanningTool = () => {
       staffAllocations: {},
       staffMembers: defaultStaffMembers,
       staffAssignments: defaultStaffAssignments,
+      projectEffortTemplates: defaultProjectEffortTemplates.map(
+        normalizeEffortTemplate
+      ),
     }),
     []
   );
@@ -142,6 +147,9 @@ const CapitalPlanningTool = () => {
     saveStaffMember,
     getStaffMembers,
     deleteStaffMember: dbDeleteStaffMember,
+    saveProjectEffortTemplate: dbSaveProjectEffortTemplate,
+    getProjectEffortTemplates,
+    deleteProjectEffortTemplate: dbDeleteProjectEffortTemplate,
     saveStaffAssignment,
     getStaffAssignments,
     deleteStaffAssignment: dbDeleteStaffAssignment,
@@ -156,6 +164,9 @@ const CapitalPlanningTool = () => {
   const [fundingSources, setFundingSources] = useState(defaultFundingSources);
   const [projects, setProjects] = useState(() =>
     defaultProjects.map(normalizeProjectBudgetBreakdown)
+  );
+  const [projectEffortTemplates, setProjectEffortTemplates] = useState(() =>
+    defaultProjectEffortTemplates.map(normalizeEffortTemplate)
   );
   const [staffAllocations, setStaffAllocations] = useState({});
   const [staffMembers, setStaffMembers] = useState(defaultStaffMembers);
@@ -189,6 +200,7 @@ const CapitalPlanningTool = () => {
             staffCategoriesData,
             projectTypesData,
             fundingSourcesData,
+            projectEffortTemplatesData,
             allocationsData,
             staffMembersData,
             staffAssignmentsData,
@@ -197,6 +209,7 @@ const CapitalPlanningTool = () => {
             getStaffCategories(),
             getProjectTypes(),
             getFundingSources(),
+            getProjectEffortTemplates(),
             getStaffAllocations(),
             getStaffMembers(),
             getStaffAssignments(),
@@ -221,6 +234,15 @@ const CapitalPlanningTool = () => {
           }
           if (fundingSourcesData && fundingSourcesData.length > 0) {
             setFundingSources(fundingSourcesData);
+          }
+
+          if (
+            projectEffortTemplatesData &&
+            projectEffortTemplatesData.length > 0
+          ) {
+            setProjectEffortTemplates(
+              projectEffortTemplatesData.map(normalizeEffortTemplate)
+            );
           }
 
           if (staffMembersData && staffMembersData.length > 0) {
@@ -272,6 +294,7 @@ const CapitalPlanningTool = () => {
     getStaffCategories,
     getProjectTypes,
     getFundingSources,
+    getProjectEffortTemplates,
     getStaffAllocations,
     getStaffMembers,
     getStaffAssignments,
@@ -481,6 +504,7 @@ const CapitalPlanningTool = () => {
             projectTypeId: projectTypes[0]?.id || 1,
             fundingSourceId: fundingSources[0]?.id || 1,
             deliveryType: "self-perform",
+            sizeCategory: "Medium",
             totalBudget: 1000000,
             designBudgetPercent: 15,
             constructionBudgetPercent: 85,
@@ -497,6 +521,7 @@ const CapitalPlanningTool = () => {
             projectTypeId: projectTypes[0]?.id || 1,
             fundingSourceId: fundingSources[0]?.id || 1,
             deliveryType: "self-perform",
+            sizeCategory: "Program",
             annualBudget: 500000,
             designBudgetPercent: 15,
             constructionBudgetPercent: 85,
@@ -624,6 +649,162 @@ const CapitalPlanningTool = () => {
       });
     } catch (error) {
       console.error("Error saving staff allocation:", error);
+    }
+  };
+
+  const upsertProjectEffortTemplate = async (template) => {
+    if (isReadOnly) {
+      return null;
+    }
+
+    const normalizedTemplate = normalizeEffortTemplate(template);
+    const payload = {
+      ...normalizedTemplate,
+      id: template?.id ?? normalizedTemplate.id,
+    };
+
+    try {
+      const savedId = await dbSaveProjectEffortTemplate(payload);
+      const templateId = savedId || payload.id;
+
+      const templateWithId = {
+        ...normalizedTemplate,
+        id: templateId,
+      };
+
+      setProjectEffortTemplates((previous) => {
+        const existingIndex = previous.findIndex(
+          (entry) => entry.id && templateId && String(entry.id) === String(templateId)
+        );
+
+        if (existingIndex >= 0) {
+          const next = [...previous];
+          next[existingIndex] = templateWithId;
+          return next;
+        }
+
+        return [...previous, templateWithId];
+      });
+
+      return templateId;
+    } catch (error) {
+      console.error("Error saving project effort template:", error);
+      return null;
+    }
+  };
+
+  const removeProjectEffortTemplate = async (templateId) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    if (!templateId) {
+      return;
+    }
+
+    try {
+      await dbDeleteProjectEffortTemplate(templateId);
+      setProjectEffortTemplates((previous) =>
+        previous.filter((template) => String(template.id) !== String(templateId))
+      );
+    } catch (error) {
+      console.error("Error deleting project effort template:", error);
+    }
+  };
+
+  const applyProjectEffortTemplate = async (template, targetProjectIds = []) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    if (!template) {
+      return;
+    }
+
+    const storedTemplate = template.id
+      ? projectEffortTemplates.find(
+          (entry) => entry.id && String(entry.id) === String(template.id)
+        )
+      : null;
+
+    const normalizedTemplate = storedTemplate || normalizeEffortTemplate(template);
+    const sanitizedHours = normalizedTemplate.hoursByCategory || {};
+
+    const categoryMap = new Map(
+      staffCategories
+        .filter((category) => category && category.id !== undefined && category.id !== null)
+        .map((category) => [String(category.id), category.id])
+    );
+
+    const validProjectIds = Array.from(
+      new Set(
+        (targetProjectIds || []).filter(
+          (projectId) => projectId !== undefined && projectId !== null
+        )
+      )
+    );
+
+    if (!validProjectIds.length || !Object.keys(sanitizedHours).length) {
+      return;
+    }
+
+    setStaffAllocations((previous) => {
+      const next = { ...previous };
+
+      validProjectIds.forEach((projectId) => {
+        const projectKey = projectId;
+        const existingProjectAllocations = {
+          ...(next[projectKey] || {}),
+        };
+
+        Object.entries(sanitizedHours).forEach(([categoryKey, hours]) => {
+          const resolvedCategoryId = categoryMap.get(String(categoryKey));
+          if (!resolvedCategoryId) {
+            return;
+          }
+
+          existingProjectAllocations[resolvedCategoryId] = {
+            pmHours: Number(hours.pmHours) || 0,
+            designHours: Number(hours.designHours) || 0,
+            constructionHours: Number(hours.constructionHours) || 0,
+          };
+        });
+
+        next[projectKey] = existingProjectAllocations;
+      });
+
+      return next;
+    });
+
+    try {
+      const tasks = [];
+
+      validProjectIds.forEach((projectId) => {
+        Object.entries(sanitizedHours).forEach(([categoryKey, hours]) => {
+          const resolvedCategoryId = categoryMap.get(String(categoryKey));
+          if (!resolvedCategoryId) {
+            return;
+          }
+
+          const storageProjectId = normalizeStorageId(projectId) ?? projectId;
+          const storageCategoryId =
+            normalizeStorageId(resolvedCategoryId) ?? resolvedCategoryId;
+
+          tasks.push(
+            saveStaffAllocation({
+              projectId: storageProjectId,
+              categoryId: storageCategoryId,
+              pmHours: Number(hours.pmHours) || 0,
+              designHours: Number(hours.designHours) || 0,
+              constructionHours: Number(hours.constructionHours) || 0,
+            })
+          );
+        });
+      });
+
+      await Promise.all(tasks);
+    } catch (error) {
+      console.error("Error applying project effort template:", error);
     }
   };
 
@@ -1509,6 +1690,10 @@ const CapitalPlanningTool = () => {
               staffCategories={staffCategories}
               staffAllocations={staffAllocations}
               updateStaffAllocation={updateStaffAllocation}
+              projectEffortTemplates={projectEffortTemplates}
+              onSaveProjectEffortTemplate={upsertProjectEffortTemplate}
+              onDeleteProjectEffortTemplate={removeProjectEffortTemplate}
+              onApplyEffortTemplate={applyProjectEffortTemplate}
               fundingSources={fundingSources}
               isReadOnly={isReadOnly}
             />

--- a/src/components/tabs/ProjectEffortTemplatesPanel.js
+++ b/src/components/tabs/ProjectEffortTemplatesPanel.js
@@ -1,0 +1,850 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Plus,
+  Edit3,
+  Trash2,
+  SlidersHorizontal,
+  Users,
+  AlertTriangle,
+  CheckCircle2,
+  X,
+} from "lucide-react";
+import {
+  normalizeEffortTemplate,
+  getTemplateTotals,
+  getMatchingProjectIds,
+  formatTemplateCriteria,
+} from "../../utils/projectEffortTemplates";
+
+const DELIVERY_OPTIONS = [
+  { value: "self-perform", label: "Self-Perform" },
+  { value: "hybrid", label: "Hybrid" },
+  { value: "consultant", label: "Consultant" },
+];
+
+const defaultDraft = {
+  id: null,
+  name: "",
+  projectTypeId: "",
+  sizeCategory: "",
+  deliveryType: "",
+  notes: "",
+  hoursByCategory: {},
+};
+
+const toStringValue = (value) => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value === 0 ? "" : value.toString();
+  }
+  const trimmed = value.toString().trim();
+  return trimmed === "0" ? "" : trimmed;
+};
+
+const TemplateFormModal = ({
+  isOpen,
+  onClose,
+  onSave,
+  staffCategories = [],
+  projectTypes = [],
+  template,
+  isReadOnly = false,
+}) => {
+  const [draft, setDraft] = useState(defaultDraft);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDraft(defaultDraft);
+      return;
+    }
+
+    const normalized = normalizeEffortTemplate(template || {});
+    const categoryConfig = {};
+
+    (staffCategories || []).forEach((category) => {
+      if (!category || category.id === undefined || category.id === null) {
+        return;
+      }
+      const key = String(category.id);
+      const entry = normalized.hoursByCategory?.[key];
+      categoryConfig[key] = {
+        pmHours: toStringValue(entry?.pmHours),
+        designHours: toStringValue(entry?.designHours),
+        constructionHours: toStringValue(entry?.constructionHours),
+      };
+    });
+
+    setDraft({
+      id: normalized.id ?? null,
+      name: normalized.name || "",
+      projectTypeId: normalized.projectTypeId ? String(normalized.projectTypeId) : "",
+      sizeCategory: normalized.sizeCategory || "",
+      deliveryType: normalized.deliveryType || "",
+      notes: normalized.notes || "",
+      hoursByCategory: categoryConfig,
+    });
+  }, [isOpen, template, staffCategories]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleFieldChange = (field) => (event) => {
+    const value = event.target.value;
+    setDraft((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  };
+
+  const handleCategoryChange = (categoryId, field, value) => {
+    if (!/^\d*(\.\d*)?$/.test(value)) {
+      return;
+    }
+    const key = String(categoryId);
+    setDraft((previous) => ({
+      ...previous,
+      hoursByCategory: {
+        ...previous.hoursByCategory,
+        [key]: {
+          ...(previous.hoursByCategory?.[key] || {}),
+          [field]: value,
+        },
+      },
+    }));
+  };
+
+  const handleSave = () => {
+    const normalized = normalizeEffortTemplate({
+      ...draft,
+      projectTypeId: draft.projectTypeId || null,
+    });
+
+    const hoursByCategory = {};
+    Object.entries(draft.hoursByCategory || {}).forEach(([key, entry]) => {
+      if (!entry) {
+        return;
+      }
+      const pm = Number(entry.pmHours);
+      const design = Number(entry.designHours);
+      const construction = Number(entry.constructionHours);
+      if (
+        (Number.isFinite(pm) && pm > 0) ||
+        (Number.isFinite(design) && design > 0) ||
+        (Number.isFinite(construction) && construction > 0)
+      ) {
+        hoursByCategory[key] = {
+          pmHours: Math.round(pm * 100) / 100 || 0,
+          designHours: Math.round(design * 100) / 100 || 0,
+          constructionHours: Math.round(construction * 100) / 100 || 0,
+        };
+      }
+    });
+
+    onSave({
+      ...normalized,
+      projectTypeId: draft.projectTypeId || null,
+      sizeCategory: draft.sizeCategory?.trim() || "",
+      deliveryType: draft.deliveryType || "",
+      notes: draft.notes?.trim() || "",
+      hoursByCategory,
+    });
+  };
+
+  const sortedCategories = (staffCategories || [])
+    .filter((category) => category && category.id != null)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const totals = sortedCategories.reduce(
+    (accumulator, category) => {
+      const key = String(category.id);
+      const entry = draft.hoursByCategory?.[key];
+      const pm = Number(entry?.pmHours) || 0;
+      const design = Number(entry?.designHours) || 0;
+      const construction = Number(entry?.constructionHours) || 0;
+
+      accumulator.pm += pm;
+      accumulator.design += design;
+      accumulator.construction += construction;
+
+      if (pm > 0 || design > 0 || construction > 0) {
+        accumulator.categories += 1;
+      }
+
+      return accumulator;
+    },
+    { pm: 0, design: 0, construction: 0, categories: 0 }
+  );
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-900/50 px-4 py-6" onClick={onClose}>
+      <div
+        className="max-h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl bg-white shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-gray-100 p-6">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {draft.id ? "Edit effort template" : "New effort template"}
+            </h2>
+            <p className="text-sm text-gray-500">
+              Define default monthly PM, design, and construction hours by staff category.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full bg-gray-100 p-2 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="grid gap-6 p-6 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm text-gray-600">
+            <span className="font-medium text-gray-700">Template name</span>
+            <input
+              type="text"
+              value={draft.name}
+              onChange={handleFieldChange("name")}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              placeholder="e.g. Small self-perform pipeline"
+              disabled={isReadOnly}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm text-gray-600">
+            <span className="font-medium text-gray-700">Project type</span>
+            <select
+              value={draft.projectTypeId}
+              onChange={handleFieldChange("projectTypeId")}
+              disabled={isReadOnly}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+            >
+              <option value="">Any type</option>
+              {(projectTypes || []).map((type) => (
+                <option key={type.id} value={type.id}>
+                  {type.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm text-gray-600">
+            <span className="font-medium text-gray-700">Project size</span>
+            <input
+              type="text"
+              value={draft.sizeCategory}
+              onChange={handleFieldChange("sizeCategory")}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+              placeholder="e.g. Small / Medium / Large"
+              disabled={isReadOnly}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm text-gray-600">
+            <span className="font-medium text-gray-700">Delivery model</span>
+            <select
+              value={draft.deliveryType}
+              onChange={handleFieldChange("deliveryType")}
+              disabled={isReadOnly}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+            >
+              <option value="">Any delivery</option>
+              {DELIVERY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="md:col-span-2 flex flex-col gap-2 text-sm text-gray-600">
+            <span className="font-medium text-gray-700">Assumptions / notes</span>
+            <textarea
+              value={draft.notes}
+              onChange={handleFieldChange("notes")}
+              placeholder="Document assumptions or key drivers behind this template."
+              rows={3}
+              disabled={isReadOnly}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200"
+            />
+          </label>
+        </div>
+
+        <div className="max-h-[45vh] overflow-y-auto border-t border-gray-100">
+          <table className="min-w-full divide-y divide-gray-100 text-sm">
+            <thead>
+              <tr className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-3">Staff category</th>
+                <th className="px-4 py-3">PM hours</th>
+                <th className="px-4 py-3">Design hours</th>
+                <th className="px-4 py-3">Construction hours</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {sortedCategories.map((category) => {
+                const key = String(category.id);
+                const entry = draft.hoursByCategory?.[key] || {
+                  pmHours: "",
+                  designHours: "",
+                  constructionHours: "",
+                };
+
+                return (
+                  <tr key={category.id} className="bg-white">
+                    <td className="px-4 py-3 font-medium text-gray-700">
+                      {category.name}
+                    </td>
+                    <td className="px-4 py-3">
+                      <input
+                        type="text"
+                        inputMode="decimal"
+                        value={entry.pmHours}
+                        onChange={(event) =>
+                          handleCategoryChange(category.id, "pmHours", event.target.value)
+                        }
+                        disabled={isReadOnly}
+                        className="w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200 disabled:cursor-not-allowed disabled:bg-gray-100"
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <input
+                        type="text"
+                        inputMode="decimal"
+                        value={entry.designHours}
+                        onChange={(event) =>
+                          handleCategoryChange(category.id, "designHours", event.target.value)
+                        }
+                        disabled={isReadOnly}
+                        className="w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200 disabled:cursor-not-allowed disabled:bg-gray-100"
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <input
+                        type="text"
+                        inputMode="decimal"
+                        value={entry.constructionHours}
+                        onChange={(event) =>
+                          handleCategoryChange(category.id, "constructionHours", event.target.value)
+                        }
+                        disabled={isReadOnly}
+                        className="w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-200 disabled:cursor-not-allowed disabled:bg-gray-100"
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-4 border-t border-gray-100 px-6 py-4 text-sm text-gray-600">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700">
+              {totals.categories} {totals.categories === 1 ? "category" : "categories"} configured
+            </span>
+            <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">
+              Total {Math.round((totals.pm + totals.design + totals.construction) * 10) / 10} hrs/month
+            </span>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isReadOnly}
+              className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                isReadOnly
+                  ? "cursor-not-allowed bg-gray-300 focus:ring-gray-200"
+                  : "bg-purple-600 hover:bg-purple-700 focus:ring-purple-400"
+              }`}
+            >
+              <SlidersHorizontal size={16} className="text-purple-100" />
+              Save template
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ApplyTemplateModal = ({
+  isOpen,
+  onClose,
+  template,
+  projects = [],
+  projectTypes = [],
+  onApply,
+  isReadOnly = false,
+}) => {
+  const normalizedTemplate = useMemo(
+    () => normalizeEffortTemplate(template || {}),
+    [template]
+  );
+
+  const matchingProjectIds = useMemo(
+    () => getMatchingProjectIds(normalizedTemplate, projects),
+    [normalizedTemplate, projects]
+  );
+
+  const [selected, setSelected] = useState(new Set());
+  const [isApplying, setIsApplying] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelected(new Set());
+      setIsApplying(false);
+      return;
+    }
+    setSelected(new Set(matchingProjectIds));
+    setIsApplying(false);
+  }, [isOpen, matchingProjectIds]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const toggleProject = (projectId) => {
+    setSelected((previous) => {
+      const next = new Set(previous);
+      if (next.has(projectId)) {
+        next.delete(projectId);
+      } else {
+        next.add(projectId);
+      }
+      return next;
+    });
+  };
+
+  const handleApply = async () => {
+    if (!onApply || isReadOnly) {
+      return;
+    }
+    setIsApplying(true);
+    try {
+      await onApply(normalizedTemplate, Array.from(selected));
+      onClose();
+    } catch (error) {
+      console.error("Error applying template:", error);
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const totals = getTemplateTotals(normalizedTemplate);
+  const templateProjects = projects.filter((project) => matchingProjectIds.includes(project.id));
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-900/50 px-4 py-6" onClick={onClose}>
+      <div
+        className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-gray-100 p-6">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Apply effort template</h2>
+            <p className="text-sm text-gray-500">
+              Select the projects that should receive the hours defined in this template.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full bg-gray-100 p-2 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="space-y-4 p-6">
+          <div className="rounded-lg border border-purple-100 bg-purple-50 p-4">
+            <p className="text-sm font-medium text-purple-900">{normalizedTemplate.name}</p>
+            <div className="mt-2 flex flex-wrap gap-2 text-xs">
+              {formatTemplateCriteria({
+                template: normalizedTemplate,
+                projectTypes,
+                deliveryOptions: DELIVERY_OPTIONS,
+              }).map((chip, index) => (
+                <span
+                  key={`${chip.label}-${index}`}
+                  className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-medium ${
+                    chip.tone === "type"
+                      ? "bg-blue-100 text-blue-800"
+                      : chip.tone === "size"
+                      ? "bg-green-100 text-green-800"
+                      : chip.tone === "delivery"
+                      ? "bg-purple-100 text-purple-800"
+                      : "bg-gray-100 text-gray-600"
+                  }`}
+                >
+                  {chip.label}
+                </span>
+              ))}
+            </div>
+            {normalizedTemplate.notes && (
+              <p className="mt-2 text-xs text-purple-700">{normalizedTemplate.notes}</p>
+            )}
+            <div className="mt-3 grid grid-cols-1 gap-2 text-xs text-purple-700 sm:grid-cols-4">
+              <div className="rounded-md bg-white px-3 py-2 shadow-sm">
+                <p className="text-[11px] uppercase tracking-wide text-purple-500">PM</p>
+                <p className="text-sm font-semibold text-purple-900">{totals.pm.toLocaleString()} hrs</p>
+              </div>
+              <div className="rounded-md bg-white px-3 py-2 shadow-sm">
+                <p className="text-[11px] uppercase tracking-wide text-purple-500">Design</p>
+                <p className="text-sm font-semibold text-purple-900">{totals.design.toLocaleString()} hrs</p>
+              </div>
+              <div className="rounded-md bg-white px-3 py-2 shadow-sm">
+                <p className="text-[11px] uppercase tracking-wide text-purple-500">Construction</p>
+                <p className="text-sm font-semibold text-purple-900">{totals.construction.toLocaleString()} hrs</p>
+              </div>
+              <div className="rounded-md bg-white px-3 py-2 shadow-sm">
+                <p className="text-[11px] uppercase tracking-wide text-purple-500">Total</p>
+                <p className="text-sm font-semibold text-purple-900">
+                  {(totals.pm + totals.design + totals.construction).toLocaleString()} hrs
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2 text-gray-600">
+                <Users size={16} /> {matchingProjectIds.length} matching {matchingProjectIds.length === 1 ? "project" : "projects"}
+              </span>
+              {matchingProjectIds.length === 0 && (
+                <span className="flex items-center gap-2 text-amber-600">
+                  <AlertTriangle size={16} /> No projects currently meet this criteria.
+                </span>
+              )}
+            </div>
+
+            <div className="max-h-64 overflow-y-auto rounded-lg border border-gray-200">
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  <tr>
+                    <th className="px-4 py-2 text-left">Apply</th>
+                    <th className="px-4 py-2 text-left">Project</th>
+                    <th className="px-4 py-2 text-left">Delivery</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {templateProjects.length === 0 && (
+                    <tr>
+                      <td colSpan={3} className="px-4 py-6 text-center text-sm text-gray-500">
+                        No matching projects yet.
+                      </td>
+                    </tr>
+                  )}
+                  {templateProjects.map((project) => (
+                    <tr key={project.id}>
+                      <td className="px-4 py-3">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                          checked={selected.has(project.id)}
+                          onChange={() => toggleProject(project.id)}
+                        />
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        <p className="font-medium text-gray-800">{project.name}</p>
+                        <p className="text-xs text-gray-500">
+                          {project.projectTypeId
+                            ? projectTypes.find((type) => String(type.id) === String(project.projectTypeId))?.name || "Unassigned"
+                            : "Unassigned"}
+                        </p>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500">
+                        {DELIVERY_OPTIONS.find(
+                          (option) => option.value === (project.deliveryType || "self-perform")
+                        )?.label || project.deliveryType || "Self-Perform"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 border-t border-gray-100 px-6 py-4 text-sm">
+          <p className="text-xs text-gray-500">
+            Applying this template will overwrite the monthly hours for the selected projects. You can make manual adjustments afterwards in the allocations grid.
+          </p>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={isReadOnly || selected.size === 0 || isApplying}
+              className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                isReadOnly || selected.size === 0 || isApplying
+                  ? "cursor-not-allowed bg-gray-300 focus:ring-gray-200"
+                  : "bg-purple-600 hover:bg-purple-700 focus:ring-purple-400"
+              }`}
+            >
+              <CheckCircle2 size={16} className="text-purple-100" />
+              Apply template
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ProjectEffortTemplatesPanel = ({
+  templates = [],
+  projects = [],
+  projectTypes = [],
+  staffCategories = [],
+  onSaveTemplate,
+  onDeleteTemplate,
+  onApplyTemplate,
+  isReadOnly = false,
+}) => {
+  const normalizedTemplates = useMemo(
+    () => (templates || []).map((template) => normalizeEffortTemplate(template)),
+    [templates]
+  );
+
+  const summaries = useMemo(
+    () =>
+      normalizedTemplates.map((template) => {
+        const totals = getTemplateTotals(template);
+        const matches = getMatchingProjectIds(template, projects);
+        return {
+          template,
+          totals,
+          matchingProjectIds: matches,
+        };
+      }),
+    [normalizedTemplates, projects]
+  );
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState(null);
+  const [isApplyOpen, setIsApplyOpen] = useState(false);
+  const [activeTemplate, setActiveTemplate] = useState(null);
+
+  const openForm = (templateToEdit = null) => {
+    setEditingTemplate(templateToEdit);
+    setIsFormOpen(true);
+  };
+
+  const closeForm = () => {
+    setEditingTemplate(null);
+    setIsFormOpen(false);
+  };
+
+  const openApplyModal = (templateToApply) => {
+    setActiveTemplate(templateToApply);
+    setIsApplyOpen(true);
+  };
+
+  const closeApplyModal = () => {
+    setActiveTemplate(null);
+    setIsApplyOpen(false);
+  };
+
+  const handleSaveTemplate = async (template) => {
+    if (!onSaveTemplate) {
+      return;
+    }
+    await onSaveTemplate(template);
+    closeForm();
+  };
+
+  const handleDeleteTemplate = async (templateId) => {
+    if (!onDeleteTemplate || !templateId) {
+      return;
+    }
+    await onDeleteTemplate(templateId);
+  };
+
+  const handleApplyTemplate = async (template, projectIds) => {
+    if (!onApplyTemplate) {
+      return;
+    }
+    await onApplyTemplate(template, projectIds);
+  };
+
+  return (
+    <section className="rounded-lg bg-white p-6 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Project effort templates</h2>
+          <p className="text-sm text-gray-500">
+            Build reusable staffing assumptions and apply them across similar projects in one step.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => openForm(null)}
+          disabled={isReadOnly}
+          className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+            isReadOnly
+              ? "cursor-not-allowed bg-gray-300 focus:ring-gray-200"
+              : "bg-purple-600 hover:bg-purple-700 focus:ring-purple-400"
+          }`}
+        >
+          <Plus size={16} className="text-purple-100" />
+          New template
+        </button>
+      </div>
+
+      {summaries.length === 0 ? (
+        <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-500">
+          No templates yet. Create your first template to quickly populate staff effort across projects.
+        </div>
+      ) : (
+        <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {summaries.map(({ template, totals, matchingProjectIds }) => (
+            <div key={template.id || template.name} className="flex h-full flex-col justify-between rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <div className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold text-gray-900">
+                      {template.name}
+                    </h3>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                      {formatTemplateCriteria({
+                        template,
+                        projectTypes,
+                        deliveryOptions: DELIVERY_OPTIONS,
+                      }).map((chip, index) => (
+                        <span
+                          key={`${chip.label}-${index}`}
+                          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-medium ${
+                            chip.tone === "type"
+                              ? "bg-blue-100 text-blue-800"
+                              : chip.tone === "size"
+                              ? "bg-green-100 text-green-800"
+                              : chip.tone === "delivery"
+                              ? "bg-purple-100 text-purple-800"
+                              : "bg-gray-100 text-gray-600"
+                          }`}
+                        >
+                          {chip.label}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => openForm(template)}
+                      disabled={isReadOnly}
+                      className={`rounded-md border px-2 py-1 text-xs font-medium transition ${
+                        isReadOnly
+                          ? "cursor-not-allowed border-gray-200 text-gray-300"
+                          : "border-blue-200 text-blue-600 hover:border-blue-300 hover:text-blue-700"
+                      }`}
+                    >
+                      <Edit3 size={14} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteTemplate(template.id)}
+                      disabled={isReadOnly}
+                      className={`rounded-md border px-2 py-1 text-xs font-medium transition ${
+                        isReadOnly
+                          ? "cursor-not-allowed border-gray-200 text-gray-300"
+                          : "border-red-200 text-red-600 hover:border-red-300 hover:text-red-700"
+                      }`}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                </div>
+
+                {template.notes && (
+                  <p className="text-xs text-gray-500">{template.notes}</p>
+                )}
+
+                <div className="grid grid-cols-3 gap-3 text-xs">
+                  <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-gray-700">
+                    <p className="text-[11px] uppercase tracking-wide text-gray-500">PM</p>
+                    <p className="text-sm font-semibold text-gray-900">{totals.pm.toLocaleString()} hrs</p>
+                  </div>
+                  <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-gray-700">
+                    <p className="text-[11px] uppercase tracking-wide text-gray-500">Design</p>
+                    <p className="text-sm font-semibold text-gray-900">{totals.design.toLocaleString()} hrs</p>
+                  </div>
+                  <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-gray-700">
+                    <p className="text-[11px] uppercase tracking-wide text-gray-500">Construction</p>
+                    <p className="text-sm font-semibold text-gray-900">{totals.construction.toLocaleString()} hrs</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 text-xs text-gray-500">
+                  <Users size={14} />
+                  {matchingProjectIds.length} matching {matchingProjectIds.length === 1 ? "project" : "projects"}
+                  {matchingProjectIds.length === 0 && (
+                    <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-[11px] font-medium text-amber-700">
+                      <AlertTriangle size={12} /> No matches yet
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => openApplyModal(template)}
+                disabled={isReadOnly || normalizedTemplates.length === 0}
+                className={`mt-4 inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                  isReadOnly
+                    ? "cursor-not-allowed bg-gray-200 text-gray-500 focus:ring-gray-200"
+                    : "bg-purple-600 text-white hover:bg-purple-700 focus:ring-purple-400"
+                }`}
+              >
+                <SlidersHorizontal size={16} className="text-purple-100" />
+                Apply template
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <TemplateFormModal
+        isOpen={isFormOpen}
+        onClose={closeForm}
+        onSave={handleSaveTemplate}
+        staffCategories={staffCategories}
+        projectTypes={projectTypes}
+        template={editingTemplate}
+        isReadOnly={isReadOnly}
+      />
+
+      <ApplyTemplateModal
+        isOpen={isApplyOpen}
+        onClose={closeApplyModal}
+        template={activeTemplate}
+        projects={projects}
+        projectTypes={projectTypes}
+        onApply={handleApplyTemplate}
+        isReadOnly={isReadOnly}
+      />
+    </section>
+  );
+};
+
+export default ProjectEffortTemplatesPanel;

--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -364,6 +364,11 @@ const ProjectCard = ({
                 Delivery: {deliveryLabel}
               </SummaryChip>
             )}
+            {project.sizeCategory && (
+              <SummaryChip className="bg-green-50 text-green-700">
+                Size: {project.sizeCategory}
+              </SummaryChip>
+            )}
             {Number(project.totalBudget) > 0 && (
               <SummaryChip className="bg-purple-50 text-purple-700">
                 Budget {formatGroupBudget(project.totalBudget)}
@@ -446,6 +451,22 @@ const ProjectCard = ({
               </option>
             ))}
           </select>
+        </Field>
+
+        <Field label="Project size">
+          <input
+            type="text"
+            value={project.sizeCategory || ""}
+            onChange={(event) => {
+              if (isReadOnly) {
+                return;
+              }
+              updateProject(project.id, "sizeCategory", event.target.value);
+            }}
+            className={projectInputClass}
+            placeholder="e.g. Small / Medium / Large"
+            disabled={isReadOnly}
+          />
         </Field>
 
         <Field label="Priority">

--- a/src/components/tabs/StaffAllocations.js
+++ b/src/components/tabs/StaffAllocations.js
@@ -7,6 +7,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { groupProjectsByType } from "../../utils/projectGrouping";
+import ProjectEffortTemplatesPanel from "./ProjectEffortTemplatesPanel";
 
 const HOURS_PER_FTE = 4.33 * 40;
 
@@ -240,6 +241,10 @@ const StaffAllocations = ({
   staffCategories,
   staffAllocations,
   updateStaffAllocation,
+  projectEffortTemplates = [],
+  onSaveProjectEffortTemplate,
+  onDeleteProjectEffortTemplate,
+  onApplyEffortTemplate,
   fundingSources = [],
   isReadOnly = false,
 }) => {
@@ -356,6 +361,17 @@ const StaffAllocations = ({
 
   return (
     <div className="space-y-6">
+      <ProjectEffortTemplatesPanel
+        templates={projectEffortTemplates}
+        projects={projects}
+        projectTypes={projectTypes}
+        staffCategories={staffCategories}
+        onSaveTemplate={onSaveProjectEffortTemplate}
+        onDeleteTemplate={onDeleteProjectEffortTemplate}
+        onApplyTemplate={onApplyEffortTemplate}
+        isReadOnly={isReadOnly}
+      />
+
       {projectGroups.length === 0 ? (
         <div className="bg-white rounded-lg shadow-sm p-6 text-center text-sm text-gray-500">
           No capital projects require allocations yet. Assign project types in

--- a/src/data/defaultData.js
+++ b/src/data/defaultData.js
@@ -73,6 +73,7 @@ export const defaultProjects = [
     projectTypeId: 1,
     fundingSourceId: 2,
     deliveryType: "self-perform",
+    sizeCategory: "Large",
     totalBudget: 2500000,
     designBudget: 250000,
     constructionBudget: 2250000,
@@ -92,6 +93,7 @@ export const defaultProjects = [
     projectTypeId: 2,
     fundingSourceId: 1,
     deliveryType: "self-perform",
+    sizeCategory: "Medium",
     totalBudget: 1800000,
     designBudget: 180000,
     constructionBudget: 1620000,
@@ -111,6 +113,7 @@ export const defaultProjects = [
     projectTypeId: 2,
     fundingSourceId: 1,
     deliveryType: "self-perform",
+    sizeCategory: "Program",
     annualBudget: 500000,
     designBudgetPercent: 15,
     constructionBudgetPercent: 85,
@@ -126,6 +129,23 @@ export const defaultProjects = [
     programEndDate: "2027-12-31",
     priority: "High",
     description: "Ongoing maintenance and small improvements",
+  },
+];
+
+export const defaultProjectEffortTemplates = [
+  {
+    id: 1,
+    name: "Small self-perform water project",
+    projectTypeId: 2,
+    sizeCategory: "Small",
+    deliveryType: "self-perform",
+    notes:
+      "Baseline staffing assumption for distribution projects handled internally.",
+    hoursByCategory: {
+      1: { pmHours: 80, designHours: 0, constructionHours: 40 },
+      2: { pmHours: 0, designHours: 120, constructionHours: 0 },
+      4: { pmHours: 0, designHours: 0, constructionHours: 160 },
+    },
   },
 ];
 

--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../context/AuthContext';
 import { normalizeProjectBudgetBreakdown } from '../utils/projectBudgets';
+import {
+  normalizeEffortTemplate,
+  sanitizeTemplateHours,
+} from '../utils/projectEffortTemplates';
 
 const toCamelCaseKey = (key) =>
   key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
@@ -122,6 +126,7 @@ const projectToRow = (project, organizationId) => {
     program_end_date: normalizedProject.programEndDate || null,
     priority: normalizedProject.priority || 'Medium',
     description: normalizedProject.description || '',
+    size_category: normalizeNullable(normalizedProject.sizeCategory),
     delivery_type: normalizedProject.deliveryType || 'self-perform',
   };
 };
@@ -169,6 +174,28 @@ const staffAssignmentToRow = (assignment, organizationId) => ({
   design_hours: normalizeNullable(assignment.designHours) ?? 0,
   construction_hours: normalizeNullable(assignment.constructionHours) ?? 0,
 });
+
+const projectEffortTemplateFromRow = (row) => {
+  const camel = camelizeRecord(row);
+  camel.hoursByCategory = parseJsonField(camel.hoursByCategory, {});
+  return normalizeEffortTemplate(camel);
+};
+
+const projectEffortTemplateToRow = (template, organizationId) => {
+  const normalized = normalizeEffortTemplate(template);
+  const sanitizedHours = sanitizeTemplateHours(normalized.hoursByCategory);
+
+  return {
+    organization_id: organizationId,
+    name: normalized.name,
+    project_type_id: normalizeNullable(normalized.projectTypeId),
+    size_category: normalizeNullable(normalized.sizeCategory),
+    delivery_type: normalizeNullable(normalized.deliveryType),
+    notes: normalized.notes || '',
+    hours_by_category:
+      Object.keys(sanitizedHours).length > 0 ? sanitizedHours : null,
+  };
+};
 
 const buildErrorMessage = (error, fallback) =>
   error?.message || fallback || 'Unexpected database error.';
@@ -361,11 +388,58 @@ export const useDatabase = (defaultData = {}) => {
             Object.keys(remappedContinuous).length > 0
               ? JSON.stringify(remappedContinuous)
               : null,
+          size_category: normalizedProject.sizeCategory || null,
           program_start_date: normalizedProject.programStartDate || null,
           program_end_date: normalizedProject.programEndDate || null,
           priority: normalizedProject.priority || 'Medium',
           description: normalizedProject.description || '',
           delivery_type: normalizedProject.deliveryType || 'self-perform',
+        };
+      })
+    );
+
+    await ensureEntries('project_effort_templates', () =>
+      (defaultData.projectEffortTemplates || []).map((template) => {
+        const normalizedTemplate = normalizeEffortTemplate(template);
+
+        const projectTypeName = (defaultData.projectTypes || []).find(
+          (type) => String(type.id) === String(normalizedTemplate.projectTypeId)
+        )?.name;
+
+        const remappedHours = {};
+        Object.entries(normalizedTemplate.hoursByCategory || {}).forEach(
+          ([key, value]) => {
+            const categoryName = (defaultData.staffCategories || []).find(
+              (category) => String(category.id) === String(key)
+            )?.name;
+
+            const categoryId = categoryName
+              ? categoryIdByName.get(categoryName)
+              : null;
+
+            if (!categoryId || !value) {
+              return;
+            }
+
+            remappedHours[categoryId] = {
+              pmHours: value.pmHours || 0,
+              designHours: value.designHours || 0,
+              constructionHours: value.constructionHours || 0,
+            };
+          }
+        );
+
+        return {
+          organization_id: organizationId,
+          name: normalizedTemplate.name,
+          project_type_id: projectTypeName
+            ? projectTypeIdByName.get(projectTypeName) || null
+            : null,
+          size_category: normalizedTemplate.sizeCategory || null,
+          delivery_type: normalizedTemplate.deliveryType || null,
+          notes: normalizedTemplate.notes || null,
+          hours_by_category:
+            Object.keys(remappedHours).length > 0 ? remappedHours : null,
         };
       })
     );
@@ -779,6 +853,79 @@ export const useDatabase = (defaultData = {}) => {
     [organizationId, assertReady, assertCanEdit]
   );
 
+  const saveProjectEffortTemplate = useCallback(
+    async (template) => {
+      assertReady();
+      assertCanEdit();
+
+      const payload = projectEffortTemplateToRow(template, organizationId);
+      const { organization_id, ...updatePayload } = payload;
+
+      if (template.id) {
+        const { error: updateError } = await supabase
+          .from('project_effort_templates')
+          .update(updatePayload)
+          .eq('id', template.id)
+          .eq('organization_id', organizationId);
+
+        if (updateError) {
+          throw updateError;
+        }
+
+        return template.id;
+      }
+
+      const { data, error: insertError } = await supabase
+        .from('project_effort_templates')
+        .insert(payload)
+        .select()
+        .single();
+
+      if (insertError) {
+        throw insertError;
+      }
+
+      return data?.id;
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
+  const getProjectEffortTemplates = useCallback(async () => {
+    assertReady();
+
+    const { data, error: fetchError } = await supabase
+      .from('project_effort_templates')
+      .select('*')
+      .eq('organization_id', organizationId)
+      .order('updated_at', { ascending: false });
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    return (data || []).map(projectEffortTemplateFromRow);
+  }, [organizationId, assertReady]);
+
+  const deleteProjectEffortTemplate = useCallback(
+    async (id) => {
+      assertReady();
+      assertCanEdit();
+
+      const { error: deleteError } = await supabase
+        .from('project_effort_templates')
+        .delete()
+        .eq('id', id)
+        .eq('organization_id', organizationId);
+
+      if (deleteError) {
+        throw deleteError;
+      }
+
+      return true;
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
   const saveStaffAllocation = useCallback(
     async (allocation) => {
       assertReady();
@@ -952,6 +1099,7 @@ export const useDatabase = (defaultData = {}) => {
         staffMembers: await fetchTable('staff_members'),
         staffAllocations: await fetchTable('staff_allocations'),
         staffAssignments: await fetchTable('staff_assignments'),
+        projectEffortTemplates: await fetchTable('project_effort_templates'),
       },
     };
 
@@ -989,6 +1137,9 @@ export const useDatabase = (defaultData = {}) => {
       saveStaffMember,
       getStaffMembers,
       deleteStaffMember,
+      saveProjectEffortTemplate,
+      getProjectEffortTemplates,
+      deleteProjectEffortTemplate,
       saveStaffAssignment,
       getStaffAssignments,
       deleteStaffAssignment,
@@ -1017,6 +1168,9 @@ export const useDatabase = (defaultData = {}) => {
       saveStaffMember,
       getStaffMembers,
       deleteStaffMember,
+      saveProjectEffortTemplate,
+      getProjectEffortTemplates,
+      deleteProjectEffortTemplate,
       saveStaffAssignment,
       getStaffAssignments,
       deleteStaffAssignment,

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -165,6 +165,7 @@ export const handleCSVImport = async (
           projectTypeId: 1, // Default, user can change
           fundingSourceId: 1, // Default, user can change
           deliveryType: normalizeDeliveryType(row["Delivery Type"]),
+          sizeCategory: row["Project Size"] || "",
           totalBudget,
           designBudget,
           constructionBudget,
@@ -248,6 +249,7 @@ export const downloadCSVTemplate = (staffCategories = []) => {
       "Priority",
       "Description",
       "Delivery Type",
+      "Project Size",
       "Annual Budget",
       "Design %",
       "Construction %",
@@ -281,6 +283,7 @@ export const downloadCSVTemplate = (staffCategories = []) => {
       "High",
       "Sample project description",
       "self-perform",
+      "Medium",
       "",
       "",
       "",
@@ -303,6 +306,7 @@ export const downloadCSVTemplate = (staffCategories = []) => {
       "Medium",
       "Ongoing distribution system improvements",
       "hybrid",
+      "Program",
       "750000",
       "15",
       "85",

--- a/src/utils/projectEffortTemplates.js
+++ b/src/utils/projectEffortTemplates.js
@@ -1,0 +1,146 @@
+const toNumber = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+  return Math.round(parsed * 100) / 100;
+};
+
+export const sanitizeTemplateHours = (hoursByCategory = {}) => {
+  if (!hoursByCategory || typeof hoursByCategory !== "object") {
+    return {};
+  }
+
+  const sanitized = {};
+
+  Object.entries(hoursByCategory).forEach(([key, value]) => {
+    if (!value || typeof value !== "object") {
+      return;
+    }
+
+    const pmHours = toNumber(value.pmHours);
+    const designHours = toNumber(value.designHours);
+    const constructionHours = toNumber(value.constructionHours);
+
+    if (pmHours > 0 || designHours > 0 || constructionHours > 0) {
+      sanitized[String(key)] = { pmHours, designHours, constructionHours };
+    }
+  });
+
+  return sanitized;
+};
+
+export const normalizeEffortTemplate = (template = {}) => {
+  const normalizedHours = sanitizeTemplateHours(template.hoursByCategory);
+
+  return {
+    id: template.id ?? null,
+    name: template.name?.toString().trim() || "Untitled template",
+    projectTypeId: template.projectTypeId ?? null,
+    sizeCategory: template.sizeCategory?.toString().trim() || "",
+    deliveryType: template.deliveryType?.toString().trim() || "",
+    notes: template.notes?.toString().trim() || "",
+    hoursByCategory: normalizedHours,
+  };
+};
+
+export const getTemplateTotals = (template) => {
+  const hours = sanitizeTemplateHours(template?.hoursByCategory);
+
+  return Object.values(hours).reduce(
+    (totals, entry) => {
+      totals.pm += entry.pmHours || 0;
+      totals.design += entry.designHours || 0;
+      totals.construction += entry.constructionHours || 0;
+      return totals;
+    },
+    { pm: 0, design: 0, construction: 0 }
+  );
+};
+
+const normalizeString = (value) => value?.toString().trim().toLowerCase() || "";
+
+export const getMatchingProjectIds = (template, projects = []) => {
+  if (!template) {
+    return [];
+  }
+
+  const normalizedType = template.projectTypeId
+    ? String(template.projectTypeId)
+    : null;
+  const normalizedSize = normalizeString(template.sizeCategory);
+  const normalizedDelivery = template.deliveryType
+    ? template.deliveryType.toString().trim().toLowerCase()
+    : "";
+
+  return projects
+    .filter((project) => project && project.type === "project")
+    .filter((project) => {
+      if (normalizedType && String(project.projectTypeId) !== normalizedType) {
+        return false;
+      }
+
+      if (normalizedSize) {
+        const projectSize = normalizeString(project.sizeCategory);
+        if (!projectSize || projectSize !== normalizedSize) {
+          return false;
+        }
+      }
+
+      if (normalizedDelivery) {
+        const projectDelivery = project.deliveryType
+          ? project.deliveryType.toString().trim().toLowerCase()
+          : "";
+        if (!projectDelivery || projectDelivery !== normalizedDelivery) {
+          return false;
+        }
+      }
+
+      return true;
+    })
+    .map((project) => project.id)
+    .filter((id) => id !== undefined && id !== null);
+};
+
+export const formatTemplateCriteria = ({
+  template,
+  projectTypes = [],
+  deliveryOptions = [],
+}) => {
+  if (!template) {
+    return [];
+  }
+
+  const chips = [];
+
+  if (template.projectTypeId) {
+    const match = projectTypes.find(
+      (type) => String(type.id) === String(template.projectTypeId)
+    );
+    if (match?.name) {
+      chips.push({ label: match.name, tone: "type" });
+    }
+  } else {
+    chips.push({ label: "Any type", tone: "muted" });
+  }
+
+  if (template.sizeCategory) {
+    chips.push({ label: `Size: ${template.sizeCategory}`, tone: "size" });
+  } else {
+    chips.push({ label: "Any size", tone: "muted" });
+  }
+
+  if (template.deliveryType) {
+    const match = deliveryOptions.find(
+      (option) => option.value === template.deliveryType
+    );
+    chips.push({
+      label: match?.label || `Delivery: ${template.deliveryType}`,
+      tone: "delivery",
+    });
+  } else {
+    chips.push({ label: "Any delivery", tone: "muted" });
+  }
+
+  return chips;
+};

--- a/supabase/migrations/20241105000000_project_effort_templates.sql
+++ b/supabase/migrations/20241105000000_project_effort_templates.sql
@@ -1,0 +1,39 @@
+-- Add project size category metadata and project effort templates table
+alter table public.projects
+  add column if not exists size_category text;
+
+create table if not exists public.project_effort_templates (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  name text not null,
+  project_type_id uuid references public.project_types (id) on delete set null,
+  size_category text,
+  delivery_type text,
+  notes text,
+  hours_by_category jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists project_effort_templates_org_idx
+  on public.project_effort_templates (organization_id);
+
+alter table public.project_effort_templates enable row level security;
+
+drop trigger if exists project_effort_templates_set_updated_at on public.project_effort_templates;
+create trigger project_effort_templates_set_updated_at
+before update on public.project_effort_templates
+for each row execute function public.set_updated_at();
+
+-- Multi-tenant access policies
+
+drop policy if exists "Members can view project effort templates" on public.project_effort_templates;
+create policy "Members can view project effort templates" on public.project_effort_templates
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage project effort templates" on public.project_effort_templates;
+create policy "Editors manage project effort templates" on public.project_effort_templates
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -314,6 +314,11 @@ create trigger staff_allocations_set_updated_at
 before update on public.staff_allocations
 for each row execute function public.set_updated_at();
 
+drop trigger if exists project_effort_templates_set_updated_at on public.project_effort_templates;
+create trigger project_effort_templates_set_updated_at
+before update on public.project_effort_templates
+for each row execute function public.set_updated_at();
+
 drop trigger if exists staff_assignments_set_updated_at on public.staff_assignments;
 create trigger staff_assignments_set_updated_at
 before update on public.staff_assignments
@@ -652,6 +657,7 @@ alter table public.funding_sources enable row level security;
 alter table public.staff_categories enable row level security;
 alter table public.staff_members enable row level security;
 alter table public.projects enable row level security;
+alter table public.project_effort_templates enable row level security;
 alter table public.staff_allocations enable row level security;
 alter table public.staff_assignments enable row level security;
 
@@ -793,6 +799,17 @@ using (public.is_organization_member(organization_id));
 
 drop policy if exists "Editors manage projects" on public.projects;
 create policy "Editors manage projects" on public.projects
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view project effort templates" on public.project_effort_templates;
+create policy "Members can view project effort templates" on public.project_effort_templates
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage project effort templates" on public.project_effort_templates;
+create policy "Editors manage project effort templates" on public.project_effort_templates
 for all
 using (public.can_edit_organization(organization_id))
 with check (public.can_edit_organization(organization_id));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -140,6 +140,7 @@ create table if not exists public.projects (
   program_end_date date,
   priority text default 'Medium',
   description text,
+  size_category text,
   delivery_type text default 'self-perform',
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now())
@@ -197,6 +198,20 @@ create table if not exists public.staff_allocations (
 create index if not exists staff_allocations_organization_id_idx on public.staff_allocations (organization_id);
 create index if not exists staff_allocations_project_id_idx on public.staff_allocations (project_id);
 create index if not exists staff_allocations_category_id_idx on public.staff_allocations (category_id);
+
+create table if not exists public.project_effort_templates (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  name text not null,
+  project_type_id uuid references public.project_types (id) on delete set null,
+  size_category text,
+  delivery_type text,
+  notes text,
+  hours_by_category jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+create index if not exists project_effort_templates_org_idx on public.project_effort_templates (organization_id);
 
 create table if not exists public.staff_assignments (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- add a project effort template panel with create/edit/apply workflows to the Staff Allocations tab and wire it into the planning state
- persist project effort templates and project size metadata through Supabase, default data, and shared utilities
- expose a project size field in the project management UI and CSV import/export so templates can target the correct projects

## Testing
- npm test -- --watchAll=false --passWithNoTests
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1e79c3f7c8329bc30ede48df76ace