### PR TITLE
Widen budget inputs and prevent escalation label wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The project targets modern browsers through React 18, Tailwind CSS, and Recharts
 
 Vector now tracks database changes with the Supabase CLI:
 
+- Timestamped SQL migrations live in [`supabase/migrations/`](supabase/migrations/) (for example,
+  `20240101000000_init.sql`). Apply them with the CLI to provision the schema that the React client
+  expects.
+
 - `npm run db:mig:new <name>` – scaffold a timestamped SQL file inside `supabase/migrations/`.
 - `npm run db:push` – apply all pending migrations to the linked Supabase project.
 - `npm run db:reset:local` – recreate the local development stack and re-apply migrations (mirrors `supabase db reset --force`).

--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -14,6 +14,7 @@ import {
   GitBranch,
   FileSpreadsheet,
   ChevronDown,
+  LayoutDashboard,
 } from "lucide-react";
 
 // Import components
@@ -28,6 +29,7 @@ import PeopleTab from "./tabs/PeopleTab";
 import ScenariosTab from "./tabs/ScenariosTab";
 import ReportsTab from "./tabs/ReportsTab";
 import StaffAssignmentsTab from "./tabs/StaffAssignmentsTab";
+import FinancialModelingModule from "./financial-modeling/FinancialModelingModule";
 import { isProjectOrProgram } from "../utils/projectTypes.js";
 
 // Import data and utilities
@@ -49,6 +51,17 @@ import { useDatabase } from "../hooks/useDatabase";
 import { useAuth } from "../context/AuthContext";
 import { buildStaffAssignmentPlan } from "../utils/staffAssignments";
 import { normalizeProjectBudgetBreakdown } from "../utils/projectBudgets";
+import { normalizeEffortTemplate } from "../utils/effortTemplates";
+import {
+  generateDefaultOperatingBudget,
+  ensureBudgetYears,
+  generateDefaultFundingAssumptions,
+  createDefaultFundingAssumption,
+  calculateExistingDebtSchedule,
+  sanitizeExistingDebtInstrument,
+  sanitizeExistingDebtInstrumentList,
+  sanitizeExistingDebtManualTotals,
+} from "../utils/financialModeling";
 
 const MAX_MONTHLY_FTE_HOURS = 2080 / 12;
 const CAPACITY_FIELDS = [
@@ -102,6 +115,126 @@ const normalizeStorageId = (value) => {
   return null;
 };
 
+const UTILITY_OPTIONS = [
+  { value: "water", label: "Water Utility" },
+  { value: "sewer", label: "Sewer Utility" },
+  { value: "power", label: "Electric Utility" },
+  { value: "gas", label: "Gas Utility" },
+  { value: "stormwater", label: "Stormwater Utility" },
+];
+
+if (
+  typeof globalThis !== "undefined" &&
+  typeof globalThis.normalizeEffortTemplate !== "function"
+) {
+  globalThis.normalizeEffortTemplate = normalizeEffortTemplate;
+}
+
+const createDefaultBudgetEscalations = () => ({
+  operatingRevenue: 0,
+  nonOperatingRevenue: 0,
+  omExpenses: 0,
+  salaries: 0,
+  adminExpenses: 0,
+  existingDebtService: 0,
+});
+
+const ESCALATION_FIELDS = [
+  "operatingRevenue",
+  "nonOperatingRevenue",
+  "omExpenses",
+  "salaries",
+  "adminExpenses",
+];
+
+const recalculateOperatingBudget = (budgetRows = [], budgetEscalations = {}) => {
+  if (!Array.isArray(budgetRows) || budgetRows.length === 0) {
+    return [];
+  }
+
+  const sortedRows = [...budgetRows].sort(
+    (a, b) => (Number(a?.year) || 0) - (Number(b?.year) || 0)
+  );
+  const recalculated = [];
+
+  sortedRows.forEach((row, index) => {
+    const normalizedRow = {
+      ...row,
+      year: Number(row?.year) || 0,
+      rateIncreasePercent: getNumericValue(row?.rateIncreasePercent),
+    };
+
+    if (index === 0) {
+      ESCALATION_FIELDS.forEach((field) => {
+        normalizedRow[field] = getNumericValue(row?.[field]);
+      });
+    } else {
+      const previousRow = recalculated[index - 1];
+      ESCALATION_FIELDS.forEach((field) => {
+        const rate = Number(budgetEscalations?.[field]) || 0;
+        const priorValue = getNumericValue(previousRow?.[field]);
+        normalizedRow[field] = priorValue * (1 + rate / 100);
+      });
+    }
+
+    recalculated.push(normalizedRow);
+  });
+
+  return recalculated;
+};
+
+const createDefaultFinancialConfig = (startYear) => ({
+  startYear,
+  projectionYears: 10,
+  startingCashBalance: 2500000,
+  targetCoverageRatio: 1.5,
+});
+
+const createDefaultUtilityProfile = (startYear) => ({
+  financialConfig: createDefaultFinancialConfig(startYear),
+  operatingBudget: generateDefaultOperatingBudget(startYear, 10),
+  budgetEscalations: createDefaultBudgetEscalations(),
+  existingDebtManualTotals: {},
+  existingDebtInstruments: [],
+});
+
+const applyExistingDebtToBudget = (profile, budgetOverride) => {
+  const sanitizedManual = sanitizeExistingDebtManualTotals(
+    profile.existingDebtManualTotals
+  );
+  const sanitizedInstruments = sanitizeExistingDebtInstrumentList(
+    profile.existingDebtInstruments
+  );
+
+  const schedule = calculateExistingDebtSchedule({
+    manualTotals: sanitizedManual,
+    instruments: sanitizedInstruments,
+    startYear: profile.financialConfig.startYear,
+    projectionYears: profile.financialConfig.projectionYears,
+  });
+
+  const alignedBudget = ensureBudgetYears(
+    budgetOverride || profile.operatingBudget,
+    profile.financialConfig.startYear,
+    profile.financialConfig.projectionYears
+  );
+
+  const budgetWithDebt = alignedBudget.map((row) => ({
+    ...row,
+    existingDebtService: schedule.totalsByYear[row.year] || 0,
+  }));
+
+  return {
+    profile: {
+      ...profile,
+      operatingBudget: budgetWithDebt,
+      existingDebtManualTotals: sanitizedManual,
+      existingDebtInstruments: sanitizedInstruments,
+    },
+    schedule,
+  };
+};
+
 const CapitalPlanningTool = () => {
   const { canEditActiveOrg } = useAuth();
   const isReadOnly = !canEditActiveOrg;
@@ -116,6 +249,7 @@ const CapitalPlanningTool = () => {
       staffAllocations: {},
       staffMembers: defaultStaffMembers,
       staffAssignments: defaultStaffAssignments,
+      effortTemplates: [],
     }),
     []
   );
@@ -146,6 +280,15 @@ const CapitalPlanningTool = () => {
     getStaffAssignments,
     deleteStaffAssignment: dbDeleteStaffAssignment,
     exportDatabase,
+    getUtilityProfiles,
+    saveUtilityProfile,
+    getUtilityOperatingBudgets,
+    upsertUtilityOperatingBudgetRows,
+    deleteUtilityOperatingBudgetsNotIn,
+    getProjectTypeUtilities,
+    saveProjectTypeUtility,
+    getFundingSourceAssumptions,
+    saveFundingSourceAssumption,
   } = useDatabase(defaultData);
 
   // Core data states
@@ -159,8 +302,24 @@ const CapitalPlanningTool = () => {
   );
   const [staffAllocations, setStaffAllocations] = useState({});
   const [staffMembers, setStaffMembers] = useState(defaultStaffMembers);
+  const currentYear = useMemo(() => new Date().getFullYear(), []);
+  const [utilityProfiles, setUtilityProfiles] = useState(() => {
+    const profiles = {};
+    UTILITY_OPTIONS.forEach((option) => {
+      profiles[option.value] = createDefaultUtilityProfile(currentYear);
+    });
+    return profiles;
+  });
+  const [activeUtility, setActiveUtility] = useState(
+    UTILITY_OPTIONS[0]?.value || "water"
+  );
+  const [projectTypeUtilities, setProjectTypeUtilities] = useState({});
+  const [fundingSourceAssumptions, setFundingSourceAssumptions] = useState(() =>
+    generateDefaultFundingAssumptions(defaultFundingSources)
+  );
   const [staffAssignmentOverrides, setStaffAssignmentOverrides] = useState({});
   const [activeTab, setActiveTab] = useState("overview");
+  const [activeModule, setActiveModule] = useState("planning");
   const [activeDropdown, setActiveDropdown] = useState(null);
   const dropdownRefs = useRef({});
   const [timeHorizon, setTimeHorizon] = useState(36);
@@ -179,6 +338,40 @@ const CapitalPlanningTool = () => {
   ]);
   const [activeScenarioId, setActiveScenarioId] = useState("baseline");
 
+  useEffect(() => {
+    if (!Array.isArray(projectTypes)) {
+      return;
+    }
+
+    setProjectTypeUtilities((previous) => {
+      const nextAssignments = { ...previous };
+      let changed = false;
+
+      projectTypes.forEach((type) => {
+        const key = toIdKey(type?.id);
+        if (!key) {
+          return;
+        }
+        if (nextAssignments[key] === undefined) {
+          nextAssignments[key] = UTILITY_OPTIONS[0]?.value || null;
+          changed = true;
+        }
+      });
+
+      Object.keys(nextAssignments).forEach((key) => {
+        const stillExists = projectTypes.some(
+          (type) => String(type?.id) === key
+        );
+        if (!stillExists) {
+          delete nextAssignments[key];
+          changed = true;
+        }
+      });
+
+      return changed ? nextAssignments : previous;
+    });
+  }, [projectTypes]);
+
   // Load data from database only once when initialized
   useEffect(() => {
     const loadData = async () => {
@@ -192,6 +385,10 @@ const CapitalPlanningTool = () => {
             allocationsData,
             staffMembersData,
             staffAssignmentsData,
+            utilityProfilesData,
+            utilityBudgetMap,
+            projectTypeUtilityAssignments,
+            fundingAssumptionsData,
           ] = await Promise.all([
             getProjects(),
             getStaffCategories(),
@@ -200,6 +397,10 @@ const CapitalPlanningTool = () => {
             getStaffAllocations(),
             getStaffMembers(),
             getStaffAssignments(),
+            getUtilityProfiles(),
+            getUtilityOperatingBudgets(),
+            getProjectTypeUtilities(),
+            getFundingSourceAssumptions(),
           ]);
 
           // Only update if we got actual data
@@ -259,6 +460,118 @@ const CapitalPlanningTool = () => {
             });
             setStaffAllocations(allocationsObject);
           }
+
+          const hasUtilityProfileData =
+            utilityProfilesData && Object.keys(utilityProfilesData).length > 0;
+          const hasUtilityBudgetData = utilityBudgetMap && utilityBudgetMap.size > 0;
+
+          if (hasUtilityProfileData || hasUtilityBudgetData) {
+            setUtilityProfiles((previous) => {
+              const nextProfiles = { ...previous };
+
+              UTILITY_OPTIONS.forEach((option) => {
+                const key = option.value;
+                const existingProfile = previous[key] || createDefaultUtilityProfile(currentYear);
+                const dbProfile = utilityProfilesData?.[key];
+                const mergedConfig = dbProfile?.financialConfig
+                  ? { ...existingProfile.financialConfig, ...dbProfile.financialConfig }
+                  : { ...existingProfile.financialConfig };
+                const mergedEscalations = dbProfile?.budgetEscalations
+                  ? { ...existingProfile.budgetEscalations, ...dbProfile.budgetEscalations }
+                  : { ...existingProfile.budgetEscalations };
+                const budgetRows = utilityBudgetMap?.get(key) || existingProfile.operatingBudget;
+
+                const alignedBudget = ensureBudgetYears(
+                  budgetRows,
+                  mergedConfig.startYear,
+                  mergedConfig.projectionYears
+                );
+
+                const recalculatedBudget = recalculateOperatingBudget(
+                  alignedBudget,
+                  mergedEscalations
+                );
+
+                const manualTotals = dbProfile?.existingDebtManualTotals
+                  ? sanitizeExistingDebtManualTotals(dbProfile.existingDebtManualTotals)
+                  : sanitizeExistingDebtManualTotals(
+                      existingProfile.existingDebtManualTotals
+                    );
+
+                const instrumentList = dbProfile?.existingDebtInstruments
+                  ? sanitizeExistingDebtInstrumentList(dbProfile.existingDebtInstruments)
+                  : sanitizeExistingDebtInstrumentList(
+                      existingProfile.existingDebtInstruments
+                    );
+
+                const { profile: profileWithDebt } = applyExistingDebtToBudget(
+                  {
+                    financialConfig: mergedConfig,
+                    budgetEscalations: mergedEscalations,
+                    operatingBudget: recalculatedBudget,
+                    existingDebtManualTotals: manualTotals,
+                    existingDebtInstruments: instrumentList,
+                  },
+                  recalculatedBudget
+                );
+
+                nextProfiles[key] = profileWithDebt;
+              });
+
+              return nextProfiles;
+            });
+          }
+
+          if (
+            projectTypeUtilityAssignments &&
+            Object.keys(projectTypeUtilityAssignments).length > 0
+          ) {
+            setProjectTypeUtilities(projectTypeUtilityAssignments);
+          }
+
+          if (fundingAssumptionsData && fundingAssumptionsData.length > 0) {
+            setFundingSourceAssumptions((previous) => {
+              const existingById = new Map();
+              (previous || []).forEach((assumption) => {
+                if (!assumption) {
+                  return;
+                }
+                const key =
+                  assumption.fundingSourceId === null || assumption.fundingSourceId === undefined
+                    ? null
+                    : String(assumption.fundingSourceId);
+                if (key !== null) {
+                  existingById.set(key, assumption);
+                }
+              });
+
+              const merged = fundingAssumptionsData.map((assumption) => {
+                if (!assumption || assumption.fundingSourceId === undefined || assumption.fundingSourceId === null) {
+                  return null;
+                }
+                const key = String(assumption.fundingSourceId);
+                const existing = existingById.get(key);
+                if (existing) {
+                  return {
+                    ...existing,
+                    financingType: assumption.financingType,
+                    interestRate: assumption.interestRate,
+                    termYears: assumption.termYears,
+                    sourceName: assumption.sourceName || existing.sourceName,
+                  };
+                }
+                return {
+                  fundingSourceId: assumption.fundingSourceId,
+                  sourceName: assumption.sourceName || '',
+                  financingType: assumption.financingType || 'cash',
+                  interestRate: assumption.interestRate || 0,
+                  termYears: assumption.termYears || 0,
+                };
+              });
+
+              return merged.filter(Boolean);
+            });
+          }
         } catch (error) {
           console.error("Error loading data from database:", error);
         }
@@ -275,7 +588,45 @@ const CapitalPlanningTool = () => {
     getStaffAllocations,
     getStaffMembers,
     getStaffAssignments,
+    getUtilityProfiles,
+    getUtilityOperatingBudgets,
+    getProjectTypeUtilities,
+    getFundingSourceAssumptions,
   ]);
+
+  useEffect(() => {
+    setFundingSourceAssumptions((previous) => {
+      const existingMap = new Map();
+
+      (previous || []).forEach((assumption) => {
+        if (!assumption) {
+          return;
+        }
+        const key =
+          assumption.fundingSourceId === null ||
+          assumption.fundingSourceId === undefined
+            ? "unassigned"
+            : String(assumption.fundingSourceId);
+        existingMap.set(key, assumption);
+      });
+
+      return fundingSources.map((source) => {
+        const key =
+          source.id === null || source.id === undefined
+            ? "unassigned"
+            : String(source.id);
+        const existing = existingMap.get(key);
+        if (existing) {
+          return {
+            ...existing,
+            fundingSourceId: source.id,
+            sourceName: source.name,
+          };
+        }
+        return createDefaultFundingAssumption(source);
+      });
+    });
+  }, [fundingSources]);
 
   useEffect(() => {
     if (!activeDropdown) {
@@ -438,6 +789,12 @@ const CapitalPlanningTool = () => {
     [projects]
   );
 
+  const activeUtilityProfile = useMemo(
+    () =>
+      utilityProfiles[activeUtility] || createDefaultUtilityProfile(currentYear),
+    [utilityProfiles, activeUtility, currentYear]
+  );
+
   // Generate monthly resource forecast
   const resourceForecast = useMemo(
     () =>
@@ -467,6 +824,450 @@ const CapitalPlanningTool = () => {
       ),
     [resourceForecast, staffCategories, staffAvailabilityByCategory]
   );
+
+  const moduleOptions = [
+    {
+      id: "planning",
+      label: "Capital Planning Workspace",
+      description: "Projects, people, scheduling, and reporting.",
+      icon: LayoutDashboard,
+    },
+    {
+      id: "financial",
+      label: "Financial Modeling Suite",
+      description: "CIP spend plans, pro forma, and debt coverage analysis.",
+      icon: DollarSign,
+    },
+  ];
+
+  const handleSelectModule = (moduleId) => {
+    setActiveDropdown(null);
+    setActiveModule(moduleId);
+    if (moduleId === "planning" && activeTab === "finance") {
+      setActiveTab("overview");
+    }
+  };
+
+  const updateFinancialConfiguration = async (utilityKey, updates) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const targetUtility = utilityKey || activeUtility;
+    const existingProfile =
+      utilityProfiles[targetUtility] || createDefaultUtilityProfile(currentYear);
+
+    const nextConfig = {
+      ...existingProfile.financialConfig,
+      ...updates,
+    };
+
+    const nextBudget = ensureBudgetYears(
+      existingProfile.operatingBudget,
+      nextConfig.startYear,
+      nextConfig.projectionYears
+    );
+
+    const recalculatedBudget = recalculateOperatingBudget(
+      nextBudget,
+      existingProfile.budgetEscalations
+    );
+
+    const { profile: updatedProfile } = applyExistingDebtToBudget(
+      {
+        ...existingProfile,
+        financialConfig: nextConfig,
+        operatingBudget: recalculatedBudget,
+      },
+      recalculatedBudget
+    );
+
+    setUtilityProfiles((previous) => ({
+      ...previous,
+      [targetUtility]: updatedProfile,
+    }));
+
+    try {
+      await Promise.all([
+        saveUtilityProfile(targetUtility, {
+          financialConfig: nextConfig,
+          budgetEscalations: updatedProfile.budgetEscalations,
+          existingDebtManualTotals: updatedProfile.existingDebtManualTotals,
+          existingDebtInstruments: updatedProfile.existingDebtInstruments,
+        }),
+        upsertUtilityOperatingBudgetRows(targetUtility, updatedProfile.operatingBudget),
+        deleteUtilityOperatingBudgetsNotIn(
+          targetUtility,
+          updatedProfile.operatingBudget.map((row) => row.year)
+        ),
+      ]);
+    } catch (error) {
+      console.error("Failed to update financial configuration:", error);
+    }
+  };
+
+  const updateOperatingBudgetValue = async (utilityKey, year, field, value) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const targetUtility = utilityKey || activeUtility;
+    const existingProfile =
+      utilityProfiles[targetUtility] || createDefaultUtilityProfile(currentYear);
+
+    const normalizedBudget = ensureBudgetYears(
+      existingProfile.operatingBudget,
+      existingProfile.financialConfig.startYear,
+      existingProfile.financialConfig.projectionYears
+    );
+
+    const updatedBudget = normalizedBudget.map((row) => {
+      if (!row || row.year !== year) {
+        return row;
+      }
+
+      let nextValue = value;
+      if (field === "rateIncreasePercent") {
+        nextValue = Number(value) || 0;
+      } else {
+        nextValue = getNumericValue(value);
+      }
+
+      return {
+        ...row,
+        [field]: nextValue,
+      };
+    });
+
+    const recalculatedBudget = recalculateOperatingBudget(
+      updatedBudget,
+      existingProfile.budgetEscalations
+    );
+
+    const { profile: updatedProfile } = applyExistingDebtToBudget(
+      {
+        ...existingProfile,
+        operatingBudget: recalculatedBudget,
+      },
+      recalculatedBudget
+    );
+
+    setUtilityProfiles((previous) => ({
+      ...previous,
+      [targetUtility]: updatedProfile,
+    }));
+
+    try {
+      await upsertUtilityOperatingBudgetRows(targetUtility, updatedProfile.operatingBudget);
+      await deleteUtilityOperatingBudgetsNotIn(
+        targetUtility,
+        updatedProfile.operatingBudget.map((row) => row.year)
+      );
+    } catch (error) {
+      console.error("Failed to update operating budget row:", error);
+    }
+  };
+
+  const updateBudgetEscalation = async (utilityKey, field, value) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const targetUtility = utilityKey || activeUtility;
+    const existingProfile =
+      utilityProfiles[targetUtility] || createDefaultUtilityProfile(currentYear);
+    const numericValue = Number(value);
+
+    const updatedEscalations = {
+      ...existingProfile.budgetEscalations,
+      [field]: Number.isFinite(numericValue) ? numericValue : 0,
+    };
+
+    const normalizedBudget = ensureBudgetYears(
+      existingProfile.operatingBudget,
+      existingProfile.financialConfig.startYear,
+      existingProfile.financialConfig.projectionYears
+    );
+
+    const recalculatedBudget = recalculateOperatingBudget(
+      normalizedBudget,
+      updatedEscalations
+    );
+
+    const { profile: updatedProfile } = applyExistingDebtToBudget(
+      {
+        ...existingProfile,
+        budgetEscalations: updatedEscalations,
+        operatingBudget: recalculatedBudget,
+      },
+      recalculatedBudget
+    );
+
+    setUtilityProfiles((previous) => ({
+      ...previous,
+      [targetUtility]: updatedProfile,
+    }));
+
+    try {
+      await Promise.all([
+        saveUtilityProfile(targetUtility, {
+          financialConfig: updatedProfile.financialConfig,
+          budgetEscalations: updatedEscalations,
+          existingDebtManualTotals: updatedProfile.existingDebtManualTotals,
+          existingDebtInstruments: updatedProfile.existingDebtInstruments,
+        }),
+        upsertUtilityOperatingBudgetRows(targetUtility, updatedProfile.operatingBudget),
+        deleteUtilityOperatingBudgetsNotIn(
+          targetUtility,
+          updatedProfile.operatingBudget.map((row) => row.year)
+        ),
+      ]);
+    } catch (error) {
+      console.error("Failed to update budget escalation:", error);
+    }
+  };
+
+  const updateExistingDebtManualValue = async (utilityKey, year, value) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const targetUtility = utilityKey || activeUtility;
+    const existingProfile =
+      utilityProfiles[targetUtility] || createDefaultUtilityProfile(currentYear);
+
+    const numericYear = Number(year);
+    if (!Number.isFinite(numericYear)) {
+      return;
+    }
+
+    const manualTotals = {
+      ...sanitizeExistingDebtManualTotals(existingProfile.existingDebtManualTotals),
+    };
+
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue) || numericValue <= 0) {
+      delete manualTotals[numericYear];
+    } else {
+      manualTotals[numericYear] = numericValue;
+    }
+
+    const { profile: updatedProfile } = applyExistingDebtToBudget(
+      {
+        ...existingProfile,
+        existingDebtManualTotals: manualTotals,
+      },
+      existingProfile.operatingBudget
+    );
+
+    setUtilityProfiles((previous) => ({
+      ...previous,
+      [targetUtility]: updatedProfile,
+    }));
+
+    try {
+      await Promise.all([
+        saveUtilityProfile(targetUtility, {
+          financialConfig: updatedProfile.financialConfig,
+          budgetEscalations: updatedProfile.budgetEscalations,
+          existingDebtManualTotals: updatedProfile.existingDebtManualTotals,
+          existingDebtInstruments: updatedProfile.existingDebtInstruments,
+        }),
+        upsertUtilityOperatingBudgetRows(targetUtility, updatedProfile.operatingBudget),
+        deleteUtilityOperatingBudgetsNotIn(
+          targetUtility,
+          updatedProfile.operatingBudget.map((row) => row.year)
+        ),
+      ]);
+    } catch (error) {
+      console.error("Failed to update existing debt schedule:", error);
+    }
+  };
+
+  const addExistingDebtInstrument = async (utilityKey, instrumentInput) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const targetUtility = utilityKey || activeUtility;
+    const existingProfile =
+      utilityProfiles[targetUtility] || createDefaultUtilityProfile(currentYear);
+
+    const sanitizedInstrument = sanitizeExistingDebtInstrument(instrumentInput);
+    if (!sanitizedInstrument || !(sanitizedInstrument.outstandingPrincipal > 0)) {
+      return;
+    }
+
+    const instrumentList = [
+      ...sanitizeExistingDebtInstrumentList(existingProfile.existingDebtInstruments),
+      sanitizedInstrument,
+    ];
+
+    const { profile: updatedProfile } = applyExistingDebtToBudget(
+      {
+        ...existingProfile,
+        existingDebtInstruments: instrumentList,
+      },
+      existingProfile.operatingBudget
+    );
+
+    setUtilityProfiles((previous) => ({
+      ...previous,
+      [targetUtility]: updatedProfile,
+    }));
+
+    try {
+      await Promise.all([
+        saveUtilityProfile(targetUtility, {
+          financialConfig: updatedProfile.financialConfig,
+          budgetEscalations: updatedProfile.budgetEscalations,
+          existingDebtManualTotals: updatedProfile.existingDebtManualTotals,
+          existingDebtInstruments: updatedProfile.existingDebtInstruments,
+        }),
+        upsertUtilityOperatingBudgetRows(targetUtility, updatedProfile.operatingBudget),
+        deleteUtilityOperatingBudgetsNotIn(
+          targetUtility,
+          updatedProfile.operatingBudget.map((row) => row.year)
+        ),
+      ]);
+    } catch (error) {
+      console.error("Failed to add existing debt instrument:", error);
+    }
+  };
+
+  const removeExistingDebtInstrument = async (utilityKey, instrumentId) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const targetUtility = utilityKey || activeUtility;
+    const existingProfile =
+      utilityProfiles[targetUtility] || createDefaultUtilityProfile(currentYear);
+
+    const instrumentList = sanitizeExistingDebtInstrumentList(
+      existingProfile.existingDebtInstruments
+    ).filter((instrument) => instrument.id !== instrumentId);
+
+    const { profile: updatedProfile } = applyExistingDebtToBudget(
+      {
+        ...existingProfile,
+        existingDebtInstruments: instrumentList,
+      },
+      existingProfile.operatingBudget
+    );
+
+    setUtilityProfiles((previous) => ({
+      ...previous,
+      [targetUtility]: updatedProfile,
+    }));
+
+    try {
+      await Promise.all([
+        saveUtilityProfile(targetUtility, {
+          financialConfig: updatedProfile.financialConfig,
+          budgetEscalations: updatedProfile.budgetEscalations,
+          existingDebtManualTotals: updatedProfile.existingDebtManualTotals,
+          existingDebtInstruments: updatedProfile.existingDebtInstruments,
+        }),
+        upsertUtilityOperatingBudgetRows(targetUtility, updatedProfile.operatingBudget),
+        deleteUtilityOperatingBudgetsNotIn(
+          targetUtility,
+          updatedProfile.operatingBudget.map((row) => row.year)
+        ),
+      ]);
+    } catch (error) {
+      console.error("Failed to remove existing debt instrument:", error);
+    }
+  };
+
+  const handleUpdateProjectTypeUtility = async (typeId, utilityValue) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const key = toIdKey(typeId);
+    if (!key) {
+      return;
+    }
+
+    const normalizedUtility =
+      utilityValue && UTILITY_OPTIONS.some((option) => option.value === utilityValue)
+        ? utilityValue
+        : null;
+
+    setProjectTypeUtilities((previous) => {
+      if (previous[key] === normalizedUtility) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [key]: normalizedUtility,
+      };
+    });
+
+    try {
+      await saveProjectTypeUtility(typeId, normalizedUtility);
+    } catch (error) {
+      console.error("Failed to update project type utility assignment:", error);
+    }
+  };
+
+  const updateFundingSourceAssumption = async (fundingSourceId, field, value) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    let updatedRecord = null;
+
+    setFundingSourceAssumptions((previous) =>
+      previous.map((assumption) => {
+        if (!assumption) {
+          return assumption;
+        }
+
+        const matches =
+          assumption.fundingSourceId === fundingSourceId ||
+          String(assumption.fundingSourceId) === String(fundingSourceId);
+
+        if (!matches) {
+          return assumption;
+        }
+
+        let nextValue = value;
+        if (field === "interestRate" || field === "termYears") {
+          nextValue = getNumericValue(value);
+        }
+
+        let nextAssumption = { ...assumption };
+
+        if (field === "financingType") {
+          nextAssumption.financingType = value;
+        } else if (field === "interestRate") {
+          nextAssumption.interestRate = getNumericValue(value);
+        } else if (field === "termYears") {
+          const numeric = Math.max(0, Math.round(getNumericValue(value)));
+          nextAssumption.termYears = numeric;
+        } else {
+          nextAssumption = {
+            ...assumption,
+            [field]: nextValue,
+          };
+        }
+
+        updatedRecord = nextAssumption;
+        return nextAssumption;
+      })
+    );
+
+    if (updatedRecord) {
+      try {
+        await saveFundingSourceAssumption(updatedRecord);
+      } catch (error) {
+        console.error("Failed to update funding source assumption:", error);
+      }
+    }
+  };
 
   // Project management functions
   const addProject = async (type = "project") => {
@@ -1295,298 +2096,369 @@ const CapitalPlanningTool = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 p-6">
-      <div className="max-w-7xl mx-auto">
-        {/* Navigation Tabs */}
-        <div className="bg-white rounded-lg shadow-sm mb-6 relative">
-          {isSaving && (
-            <div className="absolute top-4 right-4 flex items-center gap-2 text-blue-600">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
-              <span className="text-sm">Saving...</span>
-            </div>
-          )}
-          <div className="border-b border-gray-200">
-            <nav className="flex space-x-8 px-6">
-              {[
-                { id: "overview", label: "Overview", icon: Calendar },
-                {
-                  id: "projects",
-                  label: "Projects & Programs",
-                  icon: FolderOpen,
-                },
-                {
-                  type: "dropdown",
-                  id: "people-menu",
-                  label: "People",
-                  icon: Users,
-                  items: [
-                    { id: "people", label: "Staff", icon: UserCircle },
-                    { id: "assignments", label: "Assignments", icon: Users },
-                    { id: "staff", label: "Categories", icon: Settings },
-                  ],
-                },
-                {
-                  id: "allocations",
-                  label: "Effort Projections",
-                  icon: Edit3,
-                },
-                { id: "scenarios", label: "Scenarios", icon: GitBranch },
-                {
-                  id: "schedule",
-                  label: "Schedule View",
-                  icon: CalendarClock,
-                },
-                {
-                  id: "forecast",
-                  label: "Resource Forecast",
-                  icon: AlertTriangle,
-                },
-                { id: "reports", label: "Reports", icon: FileSpreadsheet },
-                { id: "settings", label: "Settings", icon: Settings },
-              ].map((tab) => {
-                if (tab.type === "dropdown") {
-                  const Icon = tab.icon;
-                  const isActive = tab.items.some((item) => item.id === activeTab);
-                  return (
-                    <div
-                      key={tab.id}
-                      className="relative"
-                      ref={(element) => {
-                        if (element) {
-                          dropdownRefs.current[tab.id] = element;
-                        } else {
-                          delete dropdownRefs.current[tab.id];
-                        }
-                      }}
-                    >
+      <div className="max-w-7xl mx-auto space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          {moduleOptions.map((module) => {
+            const Icon = module.icon;
+            const isActive = activeModule === module.id;
+            return (
+              <button
+                type="button"
+                key={module.id}
+                onClick={() => handleSelectModule(module.id)}
+                className={`flex h-full w-full items-start gap-3 rounded-lg border px-4 py-3 text-left shadow-sm transition ${
+                  isActive
+                    ? "border-blue-500 bg-blue-50 text-blue-700"
+                    : "border-slate-200 bg-white text-slate-600 hover:border-blue-300"
+                }`}
+              >
+                <span
+                  className={`rounded-full border p-2 ${
+                    isActive
+                      ? "border-blue-400 bg-blue-100 text-blue-600"
+                      : "border-slate-200 bg-slate-100 text-slate-500"
+                  }`}
+                >
+                  <Icon size={20} />
+                </span>
+                <span>
+                  <span className="block text-sm font-semibold">{module.label}</span>
+                  <span className="mt-1 block text-xs text-inherit">{module.description}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {activeModule === "planning" ? (
+          <>
+            <div className="bg-white rounded-lg shadow-sm relative">
+              {isSaving && (
+                <div className="absolute top-4 right-4 flex items-center gap-2 text-blue-600">
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+                  <span className="text-sm">Saving...</span>
+                </div>
+              )}
+              <div className="border-b border-gray-200">
+                <nav className="flex space-x-8 px-6">
+                  {[
+                    { id: "overview", label: "Overview", icon: Calendar },
+                    {
+                      id: "projects",
+                      label: "Projects & Programs",
+                      icon: FolderOpen,
+                    },
+                    {
+                      type: "dropdown",
+                      id: "people-menu",
+                      label: "People",
+                      icon: Users,
+                      items: [
+                        { id: "people", label: "Staff", icon: UserCircle },
+                        { id: "assignments", label: "Assignments", icon: Users },
+                        { id: "staff", label: "Categories", icon: Settings },
+                      ],
+                    },
+                    {
+                      id: "allocations",
+                      label: "Effort Projections",
+                      icon: Edit3,
+                    },
+                    { id: "scenarios", label: "Scenarios", icon: GitBranch },
+                    {
+                      id: "schedule",
+                      label: "Schedule View",
+                      icon: CalendarClock,
+                    },
+                    {
+                      id: "forecast",
+                      label: "Resource Forecast",
+                      icon: AlertTriangle,
+                    },
+                    { id: "reports", label: "Reports", icon: FileSpreadsheet },
+                    { id: "settings", label: "Settings", icon: Settings },
+                  ].map((tab) => {
+                    if (tab.type === "dropdown") {
+                      const Icon = tab.icon;
+                      const isActive = tab.items.some((item) => item.id === activeTab);
+                      return (
+                        <div
+                          key={tab.id}
+                          className="relative"
+                          ref={(element) => {
+                            if (element) {
+                              dropdownRefs.current[tab.id] = element;
+                            } else {
+                              delete dropdownRefs.current[tab.id];
+                            }
+                          }}
+                        >
+                          <button
+                            type="button"
+                            id={`${tab.id}-button`}
+                            onClick={() =>
+                              setActiveDropdown((current) =>
+                                current === tab.id ? null : tab.id
+                              )
+                            }
+                            className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center gap-2 ${
+                              isActive
+                                ? "border-blue-500 text-blue-600"
+                                : "border-transparent text-gray-500 hover:text-gray-700"
+                            }`}
+                            aria-haspopup="menu"
+                            aria-expanded={activeDropdown === tab.id}
+                          >
+                            <Icon size={16} />
+                            {tab.label}
+                            <ChevronDown size={14} />
+                          </button>
+                          {activeDropdown === tab.id && (
+                            <div
+                              className="absolute left-0 top-full mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10"
+                              role="menu"
+                              aria-labelledby={`${tab.id}-button`}
+                            >
+                              {tab.items.map((item) => {
+                                const SubIcon = item.icon;
+                                const isSubActive = activeTab === item.id;
+                                return (
+                                  <button
+                                    type="button"
+                                    role="menuitem"
+                                    key={item.id}
+                                    onClick={() => {
+                                      setActiveTab(item.id);
+                                      setActiveDropdown(null);
+                                    }}
+                                    className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
+                                      isSubActive
+                                        ? "bg-blue-50 text-blue-600"
+                                        : "text-gray-700 hover:bg-gray-50"
+                                    }`}
+                                  >
+                                    <SubIcon size={16} />
+                                    {item.label}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    }
+
+                    const Icon = tab.icon;
+                    return (
                       <button
                         type="button"
-                        id={`${tab.id}-button`}
-                        onClick={() =>
-                          setActiveDropdown((current) =>
-                            current === tab.id ? null : tab.id
-                          )
-                        }
+                        key={tab.id}
+                        onClick={() => {
+                          setActiveDropdown(null);
+                          setActiveTab(tab.id);
+                        }}
                         className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center gap-2 ${
-                          isActive
+                          activeTab === tab.id
                             ? "border-blue-500 text-blue-600"
                             : "border-transparent text-gray-500 hover:text-gray-700"
                         }`}
-                        aria-haspopup="menu"
-                        aria-expanded={activeDropdown === tab.id}
                       >
                         <Icon size={16} />
                         {tab.label}
-                        <ChevronDown size={14} />
                       </button>
-                      {activeDropdown === tab.id && (
-                        <div
-                          className="absolute left-0 top-full mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10"
-                          role="menu"
-                          aria-labelledby={`${tab.id}-button`}
-                        >
-                          {tab.items.map((item) => {
-                            const SubIcon = item.icon;
-                            const isSubActive = activeTab === item.id;
-                            return (
-                              <button
-                                type="button"
-                                role="menuitem"
-                                key={item.id}
-                                onClick={() => {
-                                  setActiveTab(item.id);
-                                  setActiveDropdown(null);
-                                }}
-                                className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 ${
-                                  isSubActive
-                                    ? "bg-blue-50 text-blue-600"
-                                    : "text-gray-700 hover:bg-gray-50"
-                                }`}
-                              >
-                                <SubIcon size={16} />
-                                {item.label}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  );
-                }
+                    );
+                  })}
+                </nav>
+              </div>
+            </div>
 
-                const Icon = tab.icon;
-                return (
-                  <button
-                    type="button"
-                    key={tab.id}
-                    onClick={() => {
-                      setActiveDropdown(null);
-                      setActiveTab(tab.id);
-                    }}
-                    className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center gap-2 ${
-                      activeTab === tab.id
-                        ? "border-blue-500 text-blue-600"
-                        : "border-transparent text-gray-500 hover:text-gray-700"
-                    }`}
-                  >
-                    <Icon size={16} />
-                    {tab.label}
-                  </button>
-                );
-              })}
-            </nav>
-          </div>
-        </div>
-
-        {/* Tab Content */}
-        <div className="space-y-6">
-          {activeTab === "overview" && (
-            <Overview
-              projects={projects}
-              projectTypes={projectTypes}
-              staffingGaps={staffingGaps}
-              projectTimelines={projectTimelines}
-            />
-          )}
-
-          {activeTab === "projects" && (
-            <ProjectsPrograms
-              projects={projects}
-              projectTypes={projectTypes}
-              fundingSources={fundingSources}
-              staffCategories={staffCategories}
-              addProject={addProject}
-              updateProject={updateProject}
-              deleteProject={deleteProject}
-              handleImport={handleImport}
-              isReadOnly={isReadOnly}
-            />
-          )}
-          {activeTab === "staff" && (
-            <StaffCategories
-              staffCategories={staffCategories}
-              addStaffCategory={addStaffCategory}
-              updateStaffCategory={updateStaffCategory}
-              deleteStaffCategory={deleteStaffCategory}
-              capacityWarnings={categoryCapacityWarnings}
-              maxMonthlyFteHours={MAX_MONTHLY_FTE_HOURS}
-              isReadOnly={isReadOnly}
-            />
-          )}
-
-          {activeTab === "people" && (
-            <PeopleTab
-              staffMembers={staffMembers}
-              staffCategories={staffCategories}
-              addStaffMember={addStaffMember}
-              updateStaffMember={updateStaffMember}
-              deleteStaffMember={deleteStaffMember}
-              staffAvailabilityByCategory={staffAvailabilityByCategory}
-              isReadOnly={isReadOnly}
-            />
-          )}
-
-          {activeTab === "assignments" && (
-            <StaffAssignmentsTab
-              projects={projects.filter((project) =>
-                isProjectOrProgram(project)
+            <div className="space-y-6">
+              {activeTab === "overview" && (
+                <Overview
+                  projects={projects}
+                  projectTypes={projectTypes}
+                  staffingGaps={staffingGaps}
+                  projectTimelines={projectTimelines}
+                />
               )}
-              staffMembers={staffMembers}
-              staffCategories={staffCategories}
-              staffAllocations={staffAllocations}
-              assignmentOverrides={staffAssignmentOverrides}
-              assignmentPlan={staffAssignmentPlan}
-              onUpdateAssignment={updateStaffAssignmentOverride}
-              onResetProjectAssignments={resetProjectAssignments}
-              staffAvailabilityByCategory={staffAvailabilityByCategory}
-              isReadOnly={isReadOnly}
-            />
-          )}
 
-          {activeTab === "allocations" && (
-            <StaffAllocations
-              projects={projects.filter((p) => p.type === "project")}
-              projectTypes={projectTypes}
-              staffCategories={staffCategories}
-              staffAllocations={staffAllocations}
-              updateStaffAllocation={updateStaffAllocation}
-              fundingSources={fundingSources}
-              isReadOnly={isReadOnly}
-            />
-          )}
+              {activeTab === "projects" && (
+                <ProjectsPrograms
+                  projects={projects}
+                  projectTypes={projectTypes}
+                  fundingSources={fundingSources}
+                  staffCategories={staffCategories}
+                  addProject={addProject}
+                  updateProject={updateProject}
+                  deleteProject={deleteProject}
+                  handleImport={handleImport}
+                  isReadOnly={isReadOnly}
+                />
+              )}
+              {activeTab === "staff" && (
+                <StaffCategories
+                  staffCategories={staffCategories}
+                  addStaffCategory={addStaffCategory}
+                  updateStaffCategory={updateStaffCategory}
+                  deleteStaffCategory={deleteStaffCategory}
+                  capacityWarnings={categoryCapacityWarnings}
+                  maxMonthlyFteHours={MAX_MONTHLY_FTE_HOURS}
+                  isReadOnly={isReadOnly}
+                />
+              )}
 
-          {activeTab === "scenarios" && (
-            <ScenariosTab
-              projects={projects}
-              projectTypes={projectTypes}
-              staffCategories={staffCategories}
-              staffAllocations={staffAllocations}
-              staffAvailabilityByCategory={staffAvailabilityByCategory}
-              scenarios={scenarios}
-              activeScenarioId={activeScenarioId}
-              onSelectScenario={setActiveScenarioId}
-              onCreateScenario={createScenario}
-              onDuplicateScenario={duplicateScenario}
-              onUpdateScenarioMeta={updateScenarioMeta}
-              onUpdateScenarioAdjustment={updateScenarioAdjustment}
-              onResetScenarioProject={resetScenarioProject}
-              timeHorizon={timeHorizon}
-              isReadOnly={isReadOnly}
-            />
-          )}
+              {activeTab === "people" && (
+                <PeopleTab
+                  staffMembers={staffMembers}
+                  staffCategories={staffCategories}
+                  addStaffMember={addStaffMember}
+                  updateStaffMember={updateStaffMember}
+                  deleteStaffMember={deleteStaffMember}
+                  staffAvailabilityByCategory={staffAvailabilityByCategory}
+                  isReadOnly={isReadOnly}
+                />
+              )}
 
-          {activeTab === "schedule" && (
-            <ScheduleView
-              projectTimelines={projectTimelines}
-              projectTypes={projectTypes}
-              staffCategories={staffCategories}
-              staffAllocations={staffAllocations}
-              staffAvailabilityByCategory={staffAvailabilityByCategory}
-              scheduleHorizon={scheduleHorizon}
-              setScheduleHorizon={setScheduleHorizon}
-            />
-          )}
-          {activeTab === "forecast" && (
-            <ResourceForecast
-              resourceForecast={resourceForecast}
-              staffCategories={staffCategories}
-              staffingGaps={staffingGaps}
-              timeHorizon={timeHorizon}
-              setTimeHorizon={setTimeHorizon}
-            />
-          )}
+              {activeTab === "assignments" && (
+                <StaffAssignmentsTab
+                  projects={projects.filter((project) =>
+                    isProjectOrProgram(project)
+                  )}
+                  staffMembers={staffMembers}
+                  staffCategories={staffCategories}
+                  staffAllocations={staffAllocations}
+                  assignmentOverrides={staffAssignmentOverrides}
+                  assignmentPlan={staffAssignmentPlan}
+                  onUpdateAssignment={updateStaffAssignmentOverride}
+                  onResetProjectAssignments={resetProjectAssignments}
+                  staffAvailabilityByCategory={staffAvailabilityByCategory}
+                  isReadOnly={isReadOnly}
+                />
+              )}
 
-          {activeTab === "reports" && (
-            <ReportsTab
-              projects={projects}
-              projectTypes={projectTypes}
-              fundingSources={fundingSources}
-              projectTimelines={projectTimelines}
-              staffCategories={staffCategories}
-              staffAllocations={staffAllocations}
-              staffingGaps={staffingGaps}
-              resourceForecast={resourceForecast}
-              staffMembers={staffMembers}
-              staffAssignmentPlan={staffAssignmentPlan}
-            />
-          )}
+              {activeTab === "allocations" && (
+                <StaffAllocations
+                  projects={projects.filter((p) => p.type === "project")}
+                  projectTypes={projectTypes}
+                  staffCategories={staffCategories}
+                  staffAllocations={staffAllocations}
+                  updateStaffAllocation={updateStaffAllocation}
+                  fundingSources={fundingSources}
+                  isReadOnly={isReadOnly}
+                />
+              )}
 
-          {activeTab === "settings" && (
-            <SettingsTab
-              projectTypes={projectTypes}
-              fundingSources={fundingSources}
-              addProjectType={addProjectType}
-              updateProjectType={updateProjectType}
-              deleteProjectType={deleteProjectType}
-              addFundingSource={addFundingSource}
-              updateFundingSource={updateFundingSource}
-              deleteFundingSource={deleteFundingSource}
-              isReadOnly={isReadOnly}
-            />
-          )}
-        </div>
+              {activeTab === "scenarios" && (
+                <ScenariosTab
+                  projects={projects}
+                  projectTypes={projectTypes}
+                  staffCategories={staffCategories}
+                  staffAllocations={staffAllocations}
+                  staffAvailabilityByCategory={staffAvailabilityByCategory}
+                  scenarios={scenarios}
+                  activeScenarioId={activeScenarioId}
+                  onSelectScenario={setActiveScenarioId}
+                  onCreateScenario={createScenario}
+                  onDuplicateScenario={duplicateScenario}
+                  onUpdateScenarioMeta={updateScenarioMeta}
+                  onUpdateScenarioAdjustment={updateScenarioAdjustment}
+                  onResetScenarioProject={resetScenarioProject}
+                  timeHorizon={timeHorizon}
+                  isReadOnly={isReadOnly}
+                />
+              )}
 
-        {/* Export/Import Controls */}
-        <div className="bg-white rounded-lg shadow-sm p-6 mt-6">
+              {activeTab === "schedule" && (
+                <ScheduleView
+                  projectTimelines={projectTimelines}
+                  projectTypes={projectTypes}
+                  staffCategories={staffCategories}
+                  staffAllocations={staffAllocations}
+                  staffAvailabilityByCategory={staffAvailabilityByCategory}
+                  scheduleHorizon={scheduleHorizon}
+                  setScheduleHorizon={setScheduleHorizon}
+                />
+              )}
+              {activeTab === "forecast" && (
+                <ResourceForecast
+                  resourceForecast={resourceForecast}
+                  staffCategories={staffCategories}
+                  staffingGaps={staffingGaps}
+                  timeHorizon={timeHorizon}
+                  setTimeHorizon={setTimeHorizon}
+                />
+              )}
+
+              {activeTab === "reports" && (
+                <ReportsTab
+                  projects={projects}
+                  projectTypes={projectTypes}
+                  fundingSources={fundingSources}
+                  projectTimelines={projectTimelines}
+                  staffCategories={staffCategories}
+                  staffAllocations={staffAllocations}
+                  staffingGaps={staffingGaps}
+                  resourceForecast={resourceForecast}
+                  staffMembers={staffMembers}
+                  staffAssignmentPlan={staffAssignmentPlan}
+                />
+              )}
+
+              {activeTab === "settings" && (
+                <SettingsTab
+                  projectTypes={projectTypes}
+                  fundingSources={fundingSources}
+                  addProjectType={addProjectType}
+                  updateProjectType={updateProjectType}
+                  deleteProjectType={deleteProjectType}
+                  addFundingSource={addFundingSource}
+                  updateFundingSource={updateFundingSource}
+                  deleteFundingSource={deleteFundingSource}
+                  isReadOnly={isReadOnly}
+                />
+              )}
+            </div>
+          </>
+        ) : (
+          <FinancialModelingModule
+            projectTimelines={projectTimelines}
+            projectTypes={projectTypes}
+            fundingSources={fundingSources}
+            operatingBudget={activeUtilityProfile.operatingBudget}
+            onUpdateOperatingBudget={(year, field, value) =>
+              updateOperatingBudgetValue(activeUtility, year, field, value)
+            }
+            financialConfig={activeUtilityProfile.financialConfig}
+            onUpdateFinancialConfig={(updates) =>
+              updateFinancialConfiguration(activeUtility, updates)
+            }
+            budgetEscalations={activeUtilityProfile.budgetEscalations}
+          onUpdateBudgetEscalation={(field, value) =>
+            updateBudgetEscalation(activeUtility, field, value)
+          }
+          fundingSourceAssumptions={fundingSourceAssumptions}
+          onUpdateFundingSourceAssumption={updateFundingSourceAssumption}
+          activeUtility={activeUtility}
+          onChangeUtility={(utility) => setActiveUtility(utility)}
+          utilityOptions={UTILITY_OPTIONS}
+          projectTypeUtilities={projectTypeUtilities}
+          onUpdateProjectTypeUtility={handleUpdateProjectTypeUtility}
+          isReadOnly={isReadOnly}
+          existingDebtManualTotals={activeUtilityProfile.existingDebtManualTotals}
+          existingDebtInstruments={activeUtilityProfile.existingDebtInstruments}
+          onUpdateExistingDebtManual={(year, value) =>
+            updateExistingDebtManualValue(activeUtility, year, value)
+          }
+          onAddExistingDebtInstrument={(instrument) =>
+            addExistingDebtInstrument(activeUtility, instrument)
+          }
+          onRemoveExistingDebtInstrument={(instrumentId) =>
+            removeExistingDebtInstrument(activeUtility, instrumentId)
+          }
+        />
+      )}
+
+        <div className="bg-white rounded-lg shadow-sm p-6">
           <h3 className="text-lg font-semibold mb-4">Data Management</h3>
           <div className="flex flex-wrap gap-4 items-center">
             <button

--- a/src/components/financial-modeling/FinancialModelingModule.js
+++ b/src/components/financial-modeling/FinancialModelingModule.js
@@ -1,0 +1,351 @@
+import React, { useMemo, useState } from "react";
+import {
+  calculateFinancialForecast,
+  ensureBudgetYears,
+  buildProjectSpendBreakdown,
+  calculateExistingDebtSchedule,
+} from "../../utils/financialModeling";
+import CipSummaryView from "./views/CipSummaryView";
+import OperatingBudgetView from "./views/OperatingBudgetView";
+import ProFormaView from "./views/ProFormaView";
+import DebtServiceView from "./views/DebtServiceView";
+import SettingsView from "./views/SettingsView";
+import { ClipboardList, FileSpreadsheet, LineChart, PiggyBank, Settings2 } from "lucide-react";
+
+const MODULE_VIEWS = [
+  {
+    id: "cip",
+    label: "CIP Plan",
+    description: "Summaries of project schedules, funding, and annual spend.",
+    icon: ClipboardList,
+  },
+  {
+    id: "budget",
+    label: "Operating Budget",
+    description: "Enter revenue, expense, and existing debt service assumptions.",
+    icon: FileSpreadsheet,
+  },
+  {
+    id: "proForma",
+    label: "Pro Forma",
+    description: "Utility cash flow, coverage, and reserve projections.",
+    icon: LineChart,
+  },
+  {
+    id: "debt",
+    label: "Debt Service",
+    description: "Financing assumptions and new debt schedules.",
+    icon: PiggyBank,
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    description: "Manage utility mapping and model-wide assumptions.",
+    icon: Settings2,
+  },
+];
+
+const buildFundingLabelMap = (fundingSources = [], assumptions = []) => {
+  const map = new Map();
+  map.set("unassigned", "Unassigned");
+
+  fundingSources.forEach((source) => {
+    if (source && source.id !== undefined && source.id !== null) {
+      map.set(String(source.id), source.name);
+    }
+  });
+
+  assumptions.forEach((assumption) => {
+    if (!assumption) {
+      return;
+    }
+    const key =
+      assumption.fundingSourceId === null || assumption.fundingSourceId === undefined
+        ? "unassigned"
+        : String(assumption.fundingSourceId);
+    if (assumption.sourceName) {
+      map.set(key, assumption.sourceName);
+    }
+  });
+
+  return map;
+};
+
+const buildProjectTypeMap = (projectTypes = []) => {
+  const map = new Map();
+  projectTypes.forEach((type) => {
+    if (type && type.id !== undefined && type.id !== null) {
+      map.set(type.id, type.name);
+    }
+  });
+  return map;
+};
+
+const FinancialModelingModule = ({
+  projectTimelines,
+  projectTypes,
+  fundingSources,
+  operatingBudget,
+  onUpdateOperatingBudget,
+  financialConfig,
+  onUpdateFinancialConfig,
+  fundingSourceAssumptions,
+  onUpdateFundingSourceAssumption,
+  isReadOnly,
+  activeUtility,
+  onChangeUtility,
+  utilityOptions = [],
+  projectTypeUtilities = {},
+  onUpdateProjectTypeUtility,
+  budgetEscalations = {},
+  onUpdateBudgetEscalation,
+  existingDebtManualTotals = {},
+  existingDebtInstruments = [],
+  onUpdateExistingDebtManual,
+  onAddExistingDebtInstrument,
+  onRemoveExistingDebtInstrument,
+}) => {
+  const [activeView, setActiveView] = useState("cip");
+
+  const activeUtilityOption = useMemo(
+    () => utilityOptions.find((option) => option.value === activeUtility),
+    [utilityOptions, activeUtility]
+  );
+
+  const filteredProjectTimelines = useMemo(() => {
+    if (!Array.isArray(projectTimelines)) {
+      return [];
+    }
+
+    return projectTimelines.filter((project) => {
+      const typeKey =
+        project?.projectTypeId === undefined || project?.projectTypeId === null
+          ? null
+          : String(project.projectTypeId);
+      if (!typeKey) {
+        return false;
+      }
+      const assignedUtility = projectTypeUtilities[typeKey];
+      return assignedUtility === activeUtility;
+    });
+  }, [projectTimelines, projectTypeUtilities, activeUtility]);
+
+  const forecastResult = useMemo(
+    () =>
+      calculateFinancialForecast({
+        projectTimelines: filteredProjectTimelines,
+        operatingBudget,
+        financialConfig,
+        fundingSourceAssumptions,
+      }),
+    [
+      filteredProjectTimelines,
+      operatingBudget,
+      financialConfig,
+      fundingSourceAssumptions,
+    ]
+  );
+
+  const alignedBudget = useMemo(
+    () => ensureBudgetYears(operatingBudget, financialConfig.startYear, financialConfig.projectionYears),
+    [operatingBudget, financialConfig.startYear, financialConfig.projectionYears]
+  );
+
+  const projectSpendBreakdown = useMemo(
+    () => buildProjectSpendBreakdown(filteredProjectTimelines),
+    [filteredProjectTimelines]
+  );
+
+  const projectTypeSummaries = useMemo(() => {
+    const projectCounts = new Map();
+
+    (projectTimelines || []).forEach((project) => {
+      const typeKey =
+        project?.projectTypeId === undefined || project?.projectTypeId === null
+          ? null
+          : String(project.projectTypeId);
+      if (!typeKey) {
+        return;
+      }
+      projectCounts.set(typeKey, (projectCounts.get(typeKey) || 0) + 1);
+    });
+
+    return (projectTypes || [])
+      .map((type) => {
+        if (type?.id === undefined || type?.id === null) {
+          return null;
+        }
+
+        const key = String(type.id);
+        return {
+          id: type.id,
+          name: type.name,
+          projectCount: projectCounts.get(key) || 0,
+          assignedUtility: projectTypeUtilities[key] || null,
+        };
+      })
+      .filter(Boolean);
+  }, [projectTimelines, projectTypes, projectTypeUtilities]);
+
+  const years = useMemo(() => {
+    const start = Number(financialConfig.startYear) || new Date().getFullYear();
+    const totalYears = Math.max(1, Number(financialConfig.projectionYears) || 1);
+    return Array.from({ length: totalYears }, (_, index) => start + index);
+  }, [financialConfig.startYear, financialConfig.projectionYears]);
+
+  const fundingLabelMap = useMemo(
+    () => buildFundingLabelMap(fundingSources, fundingSourceAssumptions),
+    [fundingSources, fundingSourceAssumptions]
+  );
+
+  const projectTypeMap = useMemo(
+    () => buildProjectTypeMap(projectTypes),
+    [projectTypes]
+  );
+
+  const existingDebtSchedule = useMemo(
+    () =>
+      calculateExistingDebtSchedule({
+        manualTotals: existingDebtManualTotals,
+        instruments: existingDebtInstruments,
+        startYear: financialConfig.startYear,
+        projectionYears: financialConfig.projectionYears,
+      }),
+    [
+      existingDebtManualTotals,
+      existingDebtInstruments,
+      financialConfig.startYear,
+      financialConfig.projectionYears,
+    ]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-blue-200 bg-gradient-to-br from-blue-50 to-blue-100 p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900">Financial Modeling Suite</h2>
+            <p className="mt-2 max-w-3xl text-sm text-slate-700">
+              Build a utility pro forma directly from the live CIP, operating budget, and financing strategy. Navigate
+              between views to review capital schedules, update budget drivers, evaluate pro forma results, and
+              refine debt assumptions.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 md:items-end">
+            <div className="text-right">
+              <label className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                Utility Portfolio
+              </label>
+              <select
+                value={activeUtility}
+                onChange={(event) => onChangeUtility?.(event.target.value)}
+                className="mt-1 w-52 rounded-md border border-blue-200 bg-white px-3 py-2 text-sm font-medium text-blue-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                {utilityOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="rounded-md border border-blue-200 bg-white px-4 py-2 text-sm text-blue-700">
+              Projection Window: FY {financialConfig.startYear} – FY
+              {" "}
+              {financialConfig.startYear + financialConfig.projectionYears - 1}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {MODULE_VIEWS.map((view) => {
+          const Icon = view.icon;
+          const isActive = activeView === view.id;
+          return (
+            <button
+              type="button"
+              key={view.id}
+              onClick={() => setActiveView(view.id)}
+              className={`flex h-full w-full items-start gap-3 rounded-lg border px-4 py-3 text-left shadow-sm transition ${
+                isActive
+                  ? "border-blue-500 bg-blue-50 text-blue-700"
+                  : "border-slate-200 bg-white text-slate-600 hover:border-blue-300"
+              }`}
+            >
+              <span
+                className={`rounded-full border p-2 ${
+                  isActive ? "border-blue-400 bg-blue-100 text-blue-600" : "border-slate-200 bg-slate-100 text-slate-500"
+                }`}
+              >
+                <Icon size={18} />
+              </span>
+              <span>
+                <span className="block text-sm font-semibold">{view.label}</span>
+                <span className="mt-1 block text-xs text-inherit">{view.description}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {activeView === "cip" ? (
+        <CipSummaryView
+          projectSpendBreakdown={projectSpendBreakdown}
+          years={years}
+          fundingSourceMap={fundingLabelMap}
+          projectTypeMap={projectTypeMap}
+          activeUtilityLabel={activeUtilityOption?.label}
+        />
+      ) : null}
+
+      {activeView === "budget" ? (
+        <OperatingBudgetView
+          years={years}
+          alignedBudget={alignedBudget}
+          financialConfig={financialConfig}
+          onUpdateFinancialConfig={onUpdateFinancialConfig}
+          onUpdateOperatingBudget={onUpdateOperatingBudget}
+          budgetEscalations={budgetEscalations}
+          onUpdateBudgetEscalation={onUpdateBudgetEscalation}
+          activeUtilityLabel={activeUtilityOption?.label}
+          isReadOnly={isReadOnly}
+        />
+      ) : null}
+
+      {activeView === "proForma" ? (
+        <ProFormaView forecastResult={forecastResult} financialConfig={financialConfig} />
+      ) : null}
+
+      {activeView === "debt" ? (
+        <DebtServiceView
+          years={years}
+          forecastResult={forecastResult}
+          financialConfig={financialConfig}
+          fundingSourceAssumptions={fundingSourceAssumptions}
+          fundingSourceMap={fundingLabelMap}
+          onUpdateFundingSourceAssumption={onUpdateFundingSourceAssumption}
+          existingDebtSchedule={existingDebtSchedule}
+          onUpdateExistingDebtManual={(year, value) =>
+            onUpdateExistingDebtManual?.(year, value)
+          }
+          onAddExistingDebtInstrument={onAddExistingDebtInstrument}
+          onRemoveExistingDebtInstrument={onRemoveExistingDebtInstrument}
+          isReadOnly={isReadOnly}
+        />
+      ) : null}
+
+      {activeView === "settings" ? (
+        <SettingsView
+          financialConfig={financialConfig}
+          projectTypeSummaries={projectTypeSummaries}
+          utilityOptions={utilityOptions}
+          onUpdateProjectTypeUtility={onUpdateProjectTypeUtility}
+          onUpdateFinancialConfig={onUpdateFinancialConfig}
+          isReadOnly={isReadOnly}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default FinancialModelingModule;

--- a/src/components/financial-modeling/views/CipSummaryView.js
+++ b/src/components/financial-modeling/views/CipSummaryView.js
@@ -1,0 +1,194 @@
+import React, { useMemo } from "react";
+import { formatCurrency } from "../../../utils/financialModeling";
+
+const formatDate = (value) => {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return "—";
+  }
+
+  return value.toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+};
+
+const buildScheduleLines = (entry) => {
+  if (entry.type === "program") {
+    return [
+      {
+        label: "Program",
+        value: `${formatDate(entry.programStart || entry.designStart)} – ${formatDate(
+          entry.programEnd || entry.designEnd
+        )}`,
+      },
+    ];
+  }
+
+  return [
+    {
+      label: "Design",
+      value: `${formatDate(entry.designStart)} – ${formatDate(entry.designEnd)}`,
+    },
+    {
+      label: "Construction",
+      value: `${formatDate(entry.constructionStart)} – ${formatDate(
+        entry.constructionEnd
+      )}`,
+    },
+  ];
+};
+
+const CipSummaryView = ({
+  projectSpendBreakdown = [],
+  years = [],
+  fundingSourceMap,
+  projectTypeMap,
+  activeUtilityLabel,
+}) => {
+  const totals = useMemo(() => {
+    const yearTotals = {};
+    let grandTotal = 0;
+
+    projectSpendBreakdown.forEach((entry) => {
+      years.forEach((year) => {
+        const amount = entry.spendByYear?.[year] || 0;
+        if (amount > 0) {
+          yearTotals[year] = (yearTotals[year] || 0) + amount;
+          grandTotal += amount;
+        }
+      });
+    });
+
+    return { yearTotals, grandTotal };
+  }, [projectSpendBreakdown, years]);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2">
+          <h3 className="text-lg font-semibold text-slate-900">
+            Capital Improvement Plan Overview
+          </h3>
+          <p className="text-sm text-slate-600">
+            The table below ties each capital project to its funding source, delivery schedule,
+            and expected fiscal year spend. Spending is distributed automatically from the
+            project design and construction timelines that power the broader planning suite.
+          </p>
+          {activeUtilityLabel ? (
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+              Viewing Utility Portfolio: {activeUtilityLabel}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left font-semibold text-slate-600">
+                Project / Program
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-semibold text-slate-600">
+                Type
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-semibold text-slate-600">
+                Funding Source
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-semibold text-slate-600">
+                Schedule
+              </th>
+              {years.map((year) => (
+                <th
+                  key={year}
+                  scope="col"
+                  className="px-4 py-3 text-right font-semibold text-slate-600"
+                >
+                  FY {year}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {projectSpendBreakdown.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={4 + years.length}
+                  className="px-4 py-6 text-center text-sm text-slate-500"
+                >
+                  No capital projects are scheduled. Add projects to the CIP plan to populate this
+                  view.
+                </td>
+              </tr>
+            ) : (
+              projectSpendBreakdown.map((entry) => {
+                const scheduleLines = buildScheduleLines(entry);
+                return (
+                  <tr key={entry.projectId || entry.name} className="align-top">
+                    <th scope="row" className="px-4 py-3 text-left font-medium text-slate-900">
+                      <div>{entry.name}</div>
+                      {entry.deliveryType ? (
+                        <div className="text-xs font-normal uppercase tracking-wide text-slate-400">
+                          {entry.deliveryType}
+                        </div>
+                      ) : null}
+                    </th>
+                    <td className="px-4 py-3 text-slate-600">
+                      {projectTypeMap?.get(entry.projectTypeId) ||
+                        (entry.type === "program" ? "Program" : "Project")}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {fundingSourceMap?.get(String(entry.fundingSourceId)) || "Unassigned"}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      <div className="space-y-1">
+                        {scheduleLines.map((line) => (
+                          <div key={line.label}>
+                            <span className="mr-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                              {line.label}
+                            </span>
+                            <span className="text-sm text-slate-600">{line.value}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </td>
+                    {years.map((year) => {
+                      const amount = entry.spendByYear?.[year] || 0;
+                      return (
+                        <td key={year} className="px-4 py-3 text-right text-slate-700">
+                          {amount > 0 ? formatCurrency(amount) : "—"}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+          {projectSpendBreakdown.length > 0 ? (
+            <tfoot className="bg-slate-50">
+              <tr>
+                <th
+                  scope="row"
+                  className="px-4 py-3 text-left text-sm font-semibold text-slate-700"
+                >
+                  CIP Total
+                </th>
+                <td colSpan={3} className="px-4 py-3 text-right text-sm font-semibold text-slate-700">
+                  {formatCurrency(totals.grandTotal)}
+                </td>
+                {years.map((year) => (
+                  <td key={year} className="px-4 py-3 text-right text-sm font-semibold text-slate-700">
+                    {formatCurrency(totals.yearTotals[year] || 0)}
+                  </td>
+                ))}
+              </tr>
+            </tfoot>
+          ) : null}
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default CipSummaryView;

--- a/src/components/financial-modeling/views/DebtServiceView.js
+++ b/src/components/financial-modeling/views/DebtServiceView.js
@@ -1,0 +1,827 @@
+import React, { useMemo, useState } from "react";
+import {
+  FINANCING_TYPE_OPTIONS,
+  formatCurrency,
+  formatPercent,
+  formatCoverageRatio,
+} from "../../../utils/financialModeling";
+
+const numberInputClasses =
+  "w-full rounded-md border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200";
+const readOnlyClasses = "bg-slate-100 text-slate-500 cursor-not-allowed";
+
+const defaultInstrumentForm = (years = []) => ({
+  label: "Existing Debt",
+  financingType: "bond",
+  outstandingPrincipal: "",
+  interestRate: "",
+  termYears: "",
+  firstPaymentYear: years[0] || new Date().getFullYear(),
+  interestOnlyYears: "0",
+});
+
+const DebtServiceView = ({
+  years = [],
+  existingDebtSchedule = {},
+  onUpdateExistingDebtManual,
+  onAddExistingDebtInstrument,
+  onRemoveExistingDebtInstrument,
+  forecastResult,
+  financialConfig,
+  fundingSourceAssumptions = [],
+  fundingSourceMap,
+  onUpdateFundingSourceAssumption,
+  isReadOnly,
+}) => {
+  const [instrumentForm, setInstrumentForm] = useState(() =>
+    defaultInstrumentForm(years)
+  );
+
+  const forecast = forecastResult?.forecast || [];
+  const debtIssuedBySource = forecastResult?.debtIssuedBySource || {};
+  const interestByYear = forecastResult?.debtServiceInterestByYear || {};
+  const principalByYear = forecastResult?.debtServicePrincipalByYear || {};
+  const financingSchedules = forecastResult?.financingSchedules || [];
+  const targetCoverage = financialConfig?.targetCoverageRatio || 0;
+
+  const manualByYear = existingDebtSchedule?.manualByYear || {};
+  const existingTotalsByYear = existingDebtSchedule?.totalsByYear || {};
+  const existingInstrumentSummaries = existingDebtSchedule?.instrumentSummaries || [];
+
+  const coverageByYear = useMemo(() => {
+    const map = new Map();
+    forecast.forEach((row) => {
+      if (row && row.year !== undefined && row.year !== null) {
+        map.set(row.year, row.coverageRatio);
+      }
+    });
+    return map;
+  }, [forecast]);
+
+  const bondSchedules = useMemo(
+    () =>
+      financingSchedules.filter(
+        (schedule) => schedule.financingType === "bond" && schedule.totalIssued > 0
+      ),
+    [financingSchedules]
+  );
+
+  const loanSchedules = useMemo(
+    () =>
+      financingSchedules.filter(
+        (schedule) => schedule.financingType === "srf" && schedule.totalIssued > 0
+      ),
+    [financingSchedules]
+  );
+
+  const debtSummary = useMemo(() => {
+    const entries = Object.entries(debtIssuedBySource).map(([key, amount]) => ({
+      key,
+      amount,
+      label: fundingSourceMap?.get(key) || (key === "unassigned" ? "Unassigned" : key),
+    }));
+    return entries.sort((a, b) => b.amount - a.amount);
+  }, [debtIssuedBySource, fundingSourceMap]);
+
+  const debtBySourceMap = useMemo(() => {
+    const map = new Map();
+    Object.entries(debtIssuedBySource).forEach(([key, amount]) => {
+      map.set(key, amount);
+    });
+    return map;
+  }, [debtIssuedBySource]);
+
+  const handleManualChange = (year) => (event) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    onUpdateExistingDebtManual?.(year, event.target.value);
+  };
+
+  const handleInstrumentFieldChange = (field) => (event) => {
+    const value = event.target.value;
+    setInstrumentForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const handleAddInstrument = (event) => {
+    event.preventDefault();
+    if (isReadOnly) {
+      return;
+    }
+
+    const payload = {
+      label: instrumentForm.label,
+      financingType: instrumentForm.financingType,
+      outstandingPrincipal: Number(instrumentForm.outstandingPrincipal),
+      interestRate: Number(instrumentForm.interestRate),
+      termYears: Number(instrumentForm.termYears),
+      firstPaymentYear: Number(instrumentForm.firstPaymentYear),
+      interestOnlyYears: Number(instrumentForm.interestOnlyYears),
+    };
+
+    onAddExistingDebtInstrument?.(payload);
+    setInstrumentForm(defaultInstrumentForm(years));
+  };
+
+  const handleRemoveInstrument = (id) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    onRemoveExistingDebtInstrument?.(id);
+  };
+
+  const manualRow = {
+    key: "manual",
+    label: "Existing Debt (Manual Totals)",
+    type: "manual",
+  };
+
+  const instrumentRows = existingInstrumentSummaries.map((instrument) => ({
+    key: instrument.id,
+    label: instrument.label,
+    type: "instrument",
+    financingType: instrument.financingType,
+    interestRate: instrument.interestRate,
+    termYears: instrument.termYears,
+    outstandingPrincipal: instrument.outstandingPrincipal,
+    firstPaymentYear: instrument.firstPaymentYear,
+    interestOnlyYears: instrument.interestOnlyYears,
+    summary: instrument,
+  }));
+
+  const metricRows = [manualRow, ...instrumentRows];
+
+  const totalExistingRow = {
+    key: "existingTotal",
+    label: "Total Existing Debt Service",
+    type: "total-existing",
+  };
+
+  const newDebtRows = [
+    {
+      key: "newInterest",
+      label: "New Debt Interest",
+      type: "new-interest",
+    },
+    {
+      key: "newPrincipal",
+      label: "New Debt Principal",
+      type: "new-principal",
+    },
+    {
+      key: "newTotal",
+      label: "Total New Debt Service",
+      type: "new-total",
+    },
+    {
+      key: "totalDebt",
+      label: "Total Debt Service",
+      type: "total-debt",
+    },
+    {
+      key: "coverage",
+      label: "Debt Service Coverage",
+      type: "coverage",
+    },
+  ];
+
+  const rows = [...metricRows, totalExistingRow, ...newDebtRows];
+
+  const formatCompactCurrency = (value) =>
+    formatCurrency(value, { compact: true, maximumFractionDigits: 1 });
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900">Debt Service Schedule</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              Enter manual existing debt totals or define amortizing instruments. New debt service is
+              calculated from the CIP financing assumptions.
+            </p>
+          </div>
+          <div className="text-sm text-slate-500">
+            Projection Window: FY {financialConfig.startYear} – FY
+            {" "}
+            {financialConfig.startYear + financialConfig.projectionYears - 1}
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="w-64 px-4 py-3 text-left font-semibold text-slate-600">Metric</th>
+                {years.map((year) => (
+                  <th key={year} className="px-4 py-3 text-right font-semibold text-slate-600">
+                    FY {year}
+                  </th>
+                ))}
+                <th className="px-4 py-3 text-right font-semibold text-slate-600">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.map((row) => {
+                const isTotalRow = row.type === "total-existing" || row.type === "total-debt";
+                const isCoverageRow = row.type === "coverage";
+                const labelClasses = `px-4 py-3 text-sm font-${
+                  isTotalRow ? "semibold" : "medium"
+                } text-slate-900`;
+                let labelContent = row.label;
+
+                if (row.type === "instrument") {
+                  const financingLabel =
+                    row.financingType === "srf" ? "SRF Loan" : "Revenue Bond";
+                  labelContent = (
+                    <div className="flex flex-col">
+                      <span>{row.label}</span>
+                      <span className="text-xs text-slate-500">
+                        {financingLabel} · {formatPercent(row.interestRate || 0, { decimals: 2 })} · Term {" "}
+                        {row.termYears} yrs · First Pay FY {row.firstPaymentYear}
+                      </span>
+                    </div>
+                  );
+                }
+
+                return (
+                  <tr key={row.key} className={isTotalRow ? "bg-slate-50/60" : ""}>
+                    <th scope="row" className={`${labelClasses} ${isTotalRow ? "border-t border-slate-200" : ""}`}>
+                      {labelContent}
+                    </th>
+                    {years.map((year) => {
+                      if (row.type === "manual") {
+                        const manualValue = manualByYear?.[year] ?? "";
+                        return (
+                          <td key={year} className="px-4 py-3">
+                            {isReadOnly ? (
+                              <span className="block text-right font-mono text-sm text-slate-700">
+                                {formatCompactCurrency(manualValue)}
+                              </span>
+                            ) : (
+                              <input
+                                type="number"
+                                min="0"
+                                step="1000"
+                                value={manualValue}
+                                onChange={handleManualChange(year)}
+                                className={`${numberInputClasses} min-w-[10rem] text-right ${
+                                  isReadOnly ? readOnlyClasses : ""
+                                }`}
+                                disabled={isReadOnly}
+                              />
+                            )}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "instrument") {
+                        const totalValue = row.summary?.totalsByYear?.[year] ?? 0;
+                        return (
+                          <td key={year} className="px-4 py-3 text-right font-mono text-sm text-slate-700">
+                            {formatCompactCurrency(totalValue)}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "total-existing") {
+                        return (
+                          <td key={year} className="px-4 py-3 text-right font-mono text-sm font-semibold text-slate-900">
+                            {formatCompactCurrency(existingTotalsByYear?.[year] || 0)}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "new-interest") {
+                        return (
+                          <td key={year} className="px-4 py-3 text-right font-mono text-sm text-slate-700">
+                            {formatCompactCurrency(interestByYear?.[year] || 0)}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "new-principal") {
+                        return (
+                          <td key={year} className="px-4 py-3 text-right font-mono text-sm text-slate-700">
+                            {formatCompactCurrency(principalByYear?.[year] || 0)}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "new-total") {
+                        const newDebtTotal =
+                          (interestByYear?.[year] || 0) + (principalByYear?.[year] || 0);
+                        return (
+                          <td key={year} className="px-4 py-3 text-right font-mono text-sm font-semibold text-slate-900">
+                            {formatCompactCurrency(newDebtTotal)}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "total-debt") {
+                        const newDebtTotal =
+                          (interestByYear?.[year] || 0) + (principalByYear?.[year] || 0);
+                        const combinedTotal = (existingTotalsByYear?.[year] || 0) + newDebtTotal;
+                        return (
+                          <td key={year} className="px-4 py-3 text-right font-mono text-sm font-semibold text-slate-900">
+                            {formatCompactCurrency(combinedTotal)}
+                          </td>
+                        );
+                      }
+
+                      if (row.type === "coverage") {
+                        const coverage = coverageByYear.get(year);
+                        let coverageClass = "px-4 py-3 text-right font-mono text-sm text-slate-700";
+                        if (Number.isFinite(coverage) && coverage < targetCoverage) {
+                          coverageClass = "px-4 py-3 text-right font-mono text-sm font-semibold text-red-600";
+                        }
+                        return (
+                          <td key={year} className={coverageClass}>
+                            {coverage !== null && coverage !== undefined
+                              ? formatCoverageRatio(coverage, 2)
+                              : "—"}
+                          </td>
+                        );
+                      }
+
+                      return (
+                        <td key={year} className="px-4 py-3 text-right text-slate-500">
+                          —
+                        </td>
+                      );
+                    })}
+                    <td className="px-4 py-3 text-right">
+                      {row.type === "instrument" ? (
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveInstrument(row.key)}
+                          className="text-xs font-medium text-red-600 hover:text-red-700"
+                          disabled={isReadOnly}
+                        >
+                          Remove
+                        </button>
+                      ) : (
+                        <span className="text-xs text-slate-400">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-6 rounded-md bg-slate-50 px-4 py-3 text-sm text-slate-600">
+          Existing debt totals roll into the operating budget and pro forma automatically. Manual overrides are
+          added to any instrument-based schedules defined below.
+        </div>
+
+        <div className="mt-8">
+          <h4 className="text-base font-semibold text-slate-900">Add Existing Debt Instrument</h4>
+          <p className="mt-1 text-sm text-slate-600">
+            Define an outstanding loan or bond to generate an interest and principal schedule within the
+            projection window.
+          </p>
+
+          <form
+            className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+            onSubmit={handleAddInstrument}
+          >
+            <label className="text-sm font-medium text-slate-700">
+              <span>Label</span>
+              <input
+                type="text"
+                value={instrumentForm.label}
+                onChange={handleInstrumentFieldChange("label")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly}
+                placeholder="e.g., 2018 Revenue Bonds"
+              />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              <span>Financing Type</span>
+              <select
+                value={instrumentForm.financingType}
+                onChange={handleInstrumentFieldChange("financingType")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly}
+              >
+                {FINANCING_TYPE_OPTIONS.filter((option) => option.value === "bond" || option.value === "srf").map(
+                  (option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  )
+                )}
+              </select>
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              <span>Outstanding Principal</span>
+              <input
+                type="number"
+                min="0"
+                step="1000"
+                value={instrumentForm.outstandingPrincipal}
+                onChange={handleInstrumentFieldChange("outstandingPrincipal")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly}
+                placeholder="1,000,000"
+              />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              <span>Interest Rate (%)</span>
+              <input
+                type="number"
+                step="0.01"
+                value={instrumentForm.interestRate}
+                onChange={handleInstrumentFieldChange("interestRate")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly}
+                placeholder="3.75"
+              />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              <span>Term Remaining (Years)</span>
+              <input
+                type="number"
+                step="1"
+                min="1"
+                value={instrumentForm.termYears}
+                onChange={handleInstrumentFieldChange("termYears")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly}
+                placeholder="20"
+              />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              <span>First Payment FY</span>
+              <input
+                type="number"
+                value={instrumentForm.firstPaymentYear}
+                onChange={handleInstrumentFieldChange("firstPaymentYear")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly}
+              />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              <span>Interest-Only Years</span>
+              <input
+                type="number"
+                step="1"
+                min="0"
+                value={instrumentForm.interestOnlyYears}
+                onChange={handleInstrumentFieldChange("interestOnlyYears")}
+                className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+                disabled={isReadOnly || instrumentForm.financingType !== "srf"}
+              />
+            </label>
+
+            <div className="flex items-end">
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                disabled={isReadOnly}
+              >
+                Add Instrument
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900">Financing Assumptions</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              Set financing types, interest rates, and terms for each funding source. These drive the new debt
+              service shown above.
+            </p>
+          </div>
+          <div className="text-sm text-slate-500">
+            Total New Debt Issued: {formatCurrency(forecastResult?.totals?.totalDebtIssued || 0)}
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold text-slate-600">Funding Source</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-600">Financing Type</th>
+                <th className="px-4 py-3 text-right font-semibold text-slate-600">Interest Rate %</th>
+                <th className="px-4 py-3 text-right font-semibold text-slate-600">Term (Years)</th>
+                <th className="px-4 py-3 text-right font-semibold text-slate-600">New Debt Issued</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {fundingSourceAssumptions.map((assumption) => {
+                const fundingKey =
+                  assumption.fundingSourceId === null || assumption.fundingSourceId === undefined
+                    ? "unassigned"
+                    : String(assumption.fundingSourceId);
+                const issuedAmount = debtBySourceMap.get(fundingKey) || 0;
+                return (
+                  <tr key={fundingKey}>
+                    <th scope="row" className="px-4 py-3 text-left font-medium text-slate-900">
+                      {assumption.sourceName || fundingSourceMap?.get(fundingKey) || "Funding Source"}
+                    </th>
+                    <td className="px-4 py-3">
+                      <select
+                        value={assumption.financingType}
+                        onChange={(event) =>
+                          onUpdateFundingSourceAssumption?.(
+                            assumption.fundingSourceId,
+                            "financingType",
+                            event.target.value
+                          )
+                        }
+                        className={`${numberInputClasses} ${isReadOnly ? readOnlyClasses : ""}`}
+                        disabled={isReadOnly}
+                      >
+                        {FINANCING_TYPE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {isReadOnly ? (
+                        <span className="text-slate-700">
+                          {formatPercent(assumption.interestRate || 0, { decimals: 2 })}
+                        </span>
+                      ) : (
+                        <input
+                          type="number"
+                          step="0.01"
+                          value={assumption.interestRate ?? 0}
+                          onChange={(event) =>
+                            onUpdateFundingSourceAssumption?.(
+                              assumption.fundingSourceId,
+                              "interestRate",
+                              event.target.value
+                            )
+                          }
+                          className={`${numberInputClasses} text-right ${isReadOnly ? readOnlyClasses : ""}`}
+                          disabled={isReadOnly}
+                        />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {isReadOnly ? (
+                        <span className="text-slate-700">{assumption.termYears}</span>
+                      ) : (
+                        <input
+                          type="number"
+                          step="1"
+                          min="0"
+                          value={assumption.termYears ?? 0}
+                          onChange={(event) =>
+                            onUpdateFundingSourceAssumption?.(
+                              assumption.fundingSourceId,
+                              "termYears",
+                              event.target.value
+                            )
+                          }
+                          className={`${numberInputClasses} text-right ${isReadOnly ? readOnlyClasses : ""}`}
+                          disabled={isReadOnly}
+                        />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right text-slate-700">
+                      {formatCurrency(issuedAmount)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {debtSummary.length === 0 ? (
+          <p className="mt-4 text-sm text-slate-500">
+            No new debt is projected under the current funding mix. Adjust financing assumptions or CIP schedules
+            to explore different scenarios.
+          </p>
+        ) : (
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            {debtSummary.map((item) => (
+              <div key={item.key} className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-sm">
+                <div className="font-medium text-slate-700">{item.label}</div>
+                <div className="text-slate-500">{formatCurrency(item.amount)}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {bondSchedules.length > 0 || loanSchedules.length > 0 ? (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-2">
+            <h3 className="text-lg font-semibold text-slate-900">Financing Timelines</h3>
+            <p className="text-sm text-slate-600">
+              Bond issuances and loan drawdowns are modeled from the CIP spend plan. Interest-only periods and
+              amortization start years reflect the selected financing structure.
+            </p>
+          </div>
+
+          {bondSchedules.length > 0 ? (
+            <div className="mt-6 space-y-4">
+              <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                Revenue Bond Issues
+              </h4>
+              {bondSchedules.map((schedule) => {
+                let cumulative = 0;
+                return (
+                  <div
+                    key={schedule.fundingKey || schedule.sourceName}
+                    className="rounded-md border border-slate-100 bg-white p-4 shadow-sm"
+                  >
+                    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <div className="text-sm font-semibold text-slate-800">{schedule.sourceName}</div>
+                        <div className="text-xs text-slate-500">
+                          Rate {formatPercent(schedule.interestRate || 0, { decimals: 2 })} · Term {schedule.termYears} yrs
+                        </div>
+                      </div>
+                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Total Issued: {formatCurrency(schedule.totalIssued || 0)}
+                      </div>
+                    </div>
+
+                    {schedule.issues?.length ? (
+                      <div className="mt-4 overflow-x-auto">
+                        <table className="min-w-full divide-y divide-slate-200 text-xs">
+                          <thead className="bg-slate-50">
+                            <tr>
+                              <th className="px-3 py-2 text-left font-semibold text-slate-600">Issue Year</th>
+                              <th className="px-3 py-2 text-right font-semibold text-slate-600">Issue Amount</th>
+                              <th className="px-3 py-2 text-right font-semibold text-slate-600">Payment Start</th>
+                              <th className="px-3 py-2 text-right font-semibold text-slate-600">1st Yr Interest</th>
+                              <th className="px-3 py-2 text-right font-semibold text-slate-600">1st Yr Principal</th>
+                              <th className="px-3 py-2 text-right font-semibold text-slate-600">Level Debt Service</th>
+                              <th className="px-3 py-2 text-right font-semibold text-slate-600">Cumulative Issued</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-slate-200">
+                            {schedule.issues.map((issue) => {
+                              cumulative += issue.amount || 0;
+                              return (
+                                <tr key={`${schedule.fundingKey || schedule.sourceName}-${issue.year}`}>
+                                  <th scope="row" className="px-3 py-2 text-left font-medium text-slate-700">
+                                    FY {issue.year}
+                                  </th>
+                                  <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                    {formatCurrency(issue.amount)}
+                                  </td>
+                                  <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                    FY {issue.paymentStartYear}
+                                  </td>
+                                  <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                    {formatCurrency(issue.firstYearInterest)}
+                                  </td>
+                                  <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                    {formatCurrency(issue.firstYearPrincipal)}
+                                  </td>
+                                  <td className="px-3 py-2 text-right font-mono text-slate-700">
+                                    {formatCurrency(issue.annualPayment)}
+                                  </td>
+                                  <td className="px-3 py-2 text-right font-mono text-slate-700">
+                                    {formatCurrency(cumulative)}
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <p className="mt-3 text-xs text-slate-500">No bond issues fall within the projection horizon.</p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {loanSchedules.length > 0 ? (
+            <div className="mt-8 space-y-4">
+              <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                Loan Draws & Amortization
+              </h4>
+              {loanSchedules.map((loan) => (
+                <div
+                  key={loan.fundingKey || loan.sourceName}
+                  className="rounded-md border border-slate-100 bg-white p-4 shadow-sm"
+                >
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <div className="text-sm font-semibold text-slate-800">{loan.sourceName}</div>
+                      <div className="text-xs text-slate-500">
+                        Rate {formatPercent(loan.interestRate || 0, { decimals: 2 })} · Term {loan.termYears} yrs
+                      </div>
+                    </div>
+                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      Total Financed: {formatCurrency(loan.totalIssued || 0)}
+                    </div>
+                  </div>
+
+                  {loan.interestOnly?.length ? (
+                    <div className="mt-4 overflow-x-auto">
+                      <table className="min-w-full divide-y divide-slate-200 text-xs">
+                        <thead className="bg-slate-50">
+                          <tr>
+                            <th className="px-3 py-2 text-left font-semibold text-slate-600">FY</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Draw</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Interest-Only Payment</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Balance End</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-200">
+                          {loan.interestOnly.map((entry) => (
+                            <tr key={`interest-${loan.fundingKey || loan.sourceName}-${entry.year}`}>
+                              <th scope="row" className="px-3 py-2 text-left font-medium text-slate-700">
+                                FY {entry.year}
+                              </th>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.drawAmount)}
+                              </td>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.interestPayment)}
+                              </td>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.outstandingBalance)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-xs text-slate-500">
+                      Interest-only activity falls outside the projection horizon.
+                    </p>
+                  )}
+
+                  <div className="mt-4 rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                    {loan.amortizationStartYear
+                      ? `Amortization begins FY ${loan.amortizationStartYear} with level payment ${formatCurrency(
+                          loan.annualPayment || 0
+                        )} for ${loan.termYears} years.`
+                      : "No amortization is scheduled."}
+                  </div>
+
+                  {loan.amortization?.length ? (
+                    <div className="mt-3 overflow-x-auto">
+                      <table className="min-w-full divide-y divide-slate-200 text-xs">
+                        <thead className="bg-slate-50">
+                          <tr>
+                            <th className="px-3 py-2 text-left font-semibold text-slate-600">FY</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Payment</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Interest</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Principal</th>
+                            <th className="px-3 py-2 text-right font-semibold text-slate-600">Ending Balance</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-200">
+                          {loan.amortization.map((entry) => (
+                            <tr key={`amort-${loan.fundingKey || loan.sourceName}-${entry.year}`}>
+                              <th scope="row" className="px-3 py-2 text-left font-medium text-slate-700">
+                                FY {entry.year}
+                              </th>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.payment)}
+                              </td>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.interestPayment)}
+                              </td>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.principalPayment)}
+                              </td>
+                              <td className="px-3 py-2 text-right font-mono text-slate-600">
+                                {formatCurrency(entry.remainingBalance)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-xs text-slate-500">
+                      Amortization years fall outside the projection horizon.
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default DebtServiceView;

--- a/src/components/financial-modeling/views/OperatingBudgetView.js
+++ b/src/components/financial-modeling/views/OperatingBudgetView.js
@@ -1,0 +1,337 @@
+import React from "react";
+import { formatCurrency, formatPercent } from "../../../utils/financialModeling";
+
+const numberInputClasses =
+  "w-full rounded-md border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200";
+const readOnlyClasses = "bg-slate-100 text-slate-500 cursor-not-allowed";
+
+const OperatingBudgetView = ({
+  years = [],
+  alignedBudget = [],
+  financialConfig,
+  onUpdateFinancialConfig,
+  onUpdateOperatingBudget,
+  budgetEscalations = {},
+  onUpdateBudgetEscalation,
+  activeUtilityLabel,
+  isReadOnly,
+}) => {
+  const handleConfigChange = (field) => (event) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const rawValue = event.target.value;
+    let parsedValue = rawValue;
+
+    if (field === "startYear" || field === "projectionYears") {
+      parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        parsedValue = financialConfig[field] || 0;
+      }
+      parsedValue = Math.max(field === "projectionYears" ? 1 : 1900, Math.round(parsedValue));
+    } else if (field === "startingCashBalance") {
+      parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        parsedValue = financialConfig.startingCashBalance || 0;
+      }
+    } else if (field === "targetCoverageRatio") {
+      parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        parsedValue = financialConfig.targetCoverageRatio || 1;
+      }
+      parsedValue = Math.max(0, parsedValue);
+    }
+
+    onUpdateFinancialConfig({ [field]: parsedValue });
+  };
+
+  const handleBudgetChange = (year, field) => (event) => {
+    if (isReadOnly) {
+      return;
+    }
+    onUpdateOperatingBudget(year, field, event.target.value);
+  };
+
+  const handleEscalationChange = (field) => (event) => {
+    if (isReadOnly) {
+      return;
+    }
+    const numeric = Number(event.target.value);
+    onUpdateBudgetEscalation?.(field, Number.isFinite(numeric) ? numeric : 0);
+  };
+
+  const budgetLineItems = [
+    {
+      key: "operatingRevenue",
+      label: "Operating Revenue",
+      description: "Base rate revenue before adjustments.",
+      supportsEscalation: true,
+    },
+    {
+      key: "rateIncreasePercent",
+      label: "Planned Rate Increase",
+      description: "Enter approved or proposed rate action for the fiscal year.",
+      isPercent: true,
+      step: 0.1,
+      supportsEscalation: false,
+    },
+    {
+      key: "nonOperatingRevenue",
+      label: "Non-Operating Revenue",
+      description: "Investment income, connection fees, and other sources.",
+      supportsEscalation: true,
+    },
+    {
+      key: "omExpenses",
+      label: "Operations & Maintenance",
+      description: "Chemical, power, and routine maintenance costs.",
+      supportsEscalation: true,
+    },
+    {
+      key: "salaries",
+      label: "Salaries & Wages",
+      description: "Personnel costs tied to utility operations.",
+      supportsEscalation: true,
+    },
+    {
+      key: "adminExpenses",
+      label: "Administration",
+      description: "General & administrative overhead allocations.",
+      supportsEscalation: true,
+    },
+    {
+      key: "existingDebtService",
+      label: "Existing Debt Service",
+      description: "Legacy principal and interest scheduled prior to new CIP financing.",
+      supportsEscalation: false,
+      isReadOnly: true,
+    },
+  ];
+
+  const baseYear = years?.[0];
+  const outYears = years.slice(1);
+  const baseYearNumber = Number(baseYear);
+  const hasBaseYear = Number.isFinite(baseYearNumber);
+  const baseYearLabel = hasBaseYear ? `FY ${baseYearNumber}` : "Current FY";
+
+  const budgetByYear = React.useMemo(() => {
+    const map = new Map();
+    (alignedBudget || []).forEach((row) => {
+      if (row && Number.isFinite(row.year)) {
+        map.set(Number(row.year), row);
+      }
+    });
+    return map;
+  }, [alignedBudget]);
+
+  const baseYearRow = hasBaseYear ? budgetByYear.get(baseYearNumber) || {} : {};
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-6">
+          <h3 className="text-lg font-semibold text-slate-900">Projection Settings</h3>
+          <p className="mt-1 text-sm text-slate-600">
+            Anchor the financial model with your fiscal year horizon, cash reserves, and policy targets.
+            These settings drive the pro forma and debt service coverage analysis.
+          </p>
+          {activeUtilityLabel ? (
+            <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-blue-600">
+              Configuring: {activeUtilityLabel}
+            </p>
+          ) : null}
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <label className="text-sm font-medium text-slate-700">
+            <span>Start Fiscal Year</span>
+            <input
+              type="number"
+              value={financialConfig.startYear}
+              onChange={handleConfigChange("startYear")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={1900}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            <span>Projection Years</span>
+            <input
+              type="number"
+              value={financialConfig.projectionYears}
+              onChange={handleConfigChange("projectionYears")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={1}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            <span>Starting Cash Balance</span>
+            <input
+              type="number"
+              value={financialConfig.startingCashBalance}
+              onChange={handleConfigChange("startingCashBalance")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={0}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            <span>Target Coverage Ratio</span>
+            <input
+              type="number"
+              step="0.01"
+              value={financialConfig.targetCoverageRatio}
+              onChange={handleConfigChange("targetCoverageRatio")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={0}
+            />
+          </label>
+        </div>
+        {!isReadOnly ? (
+          <div className="mt-4 text-right">
+            <button
+              type="button"
+              onClick={() =>
+                onUpdateFinancialConfig({
+                  projectionYears: (financialConfig.projectionYears || 0) + 1,
+                })
+              }
+              className="inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100"
+            >
+              Extend Projection Horizon
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-slate-900">Operating Budget Inputs</h3>
+        <p className="mt-1 text-sm text-slate-600">
+          Enter the annual budget that feeds the pro forma statement. Figures can be updated at any time to
+          reflect adopted budgets or planned rate scenarios.
+        </p>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold text-slate-600">Line Item</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-600">Notes</th>
+                <th className="px-4 py-3 text-right font-semibold text-slate-600">{baseYearLabel}</th>
+                <th className="px-4 py-3 text-right font-semibold text-slate-600 whitespace-nowrap">
+                  Escalation (%/yr)
+                </th>
+                {outYears.map((year) => (
+                  <th key={year} className="px-4 py-3 text-right font-semibold text-slate-600">
+                    FY {year}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {budgetLineItems.map((line) => {
+                const supportsEscalation = line.supportsEscalation !== false;
+                const baseValue = baseYearRow[line.key] ?? 0;
+                const escalationValue = budgetEscalations?.[line.key] ?? 0;
+                const formatDisplay = (value, options = {}) =>
+                  line.isPercent
+                    ? formatPercent(value, { decimals: 1 })
+                    : formatCurrency(value, options);
+
+                return (
+                  <tr key={line.key}>
+                    <th scope="row" className="px-4 py-3 text-left font-medium text-slate-900">
+                      {line.label}
+                    </th>
+                    <td className="px-4 py-3 text-slate-500">{line.description}</td>
+                    <td className="px-4 py-3">
+                      {hasBaseYear ? (
+                        isReadOnly ? (
+                          <span className="block text-right text-slate-700">
+                            {formatDisplay(baseValue)}
+                          </span>
+                        ) : (
+                          <input
+                            type="number"
+                            step={line.step ?? (line.isPercent ? 0.01 : 1000)}
+                            value={line.isPercent ? baseValue : baseValue || 0}
+                            onChange={handleBudgetChange(baseYearNumber, line.key)}
+                            className={`${numberInputClasses} min-w-[14rem] text-right ${
+                              isReadOnly ? readOnlyClasses : ""
+                            }`}
+                            disabled={isReadOnly || !hasBaseYear || line.isReadOnly}
+                          />
+                        )
+                      ) : (
+                        <span className="block text-right text-slate-400">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {supportsEscalation ? (
+                        isReadOnly || line.isReadOnly ? (
+                          <span className="block text-right text-slate-700">
+                            {formatPercent(escalationValue, { decimals: 1 })}
+                          </span>
+                        ) : (
+                          <div className="flex min-w-[10rem] items-center justify-end gap-2">
+                            <input
+                              type="number"
+                              step={0.1}
+                              value={escalationValue}
+                              onChange={handleEscalationChange(line.key)}
+                              className={`${numberInputClasses} w-32 text-right ${
+                                isReadOnly ? readOnlyClasses : ""
+                              }`}
+                              disabled={isReadOnly}
+                            />
+                            <span className="text-xs font-medium text-slate-500 whitespace-nowrap">
+                              (%/year)
+                            </span>
+                          </div>
+                        )
+                      ) : (
+                        <span className="block text-center text-slate-400">—</span>
+                      )}
+                    </td>
+                    {outYears.map((year) => {
+                      const numericYear = Number(year);
+                      const row = budgetByYear.get(numericYear) || {};
+                      const value = row[line.key] ?? 0;
+
+                      if (!supportsEscalation && !isReadOnly) {
+                        return (
+                          <td key={year} className="px-4 py-3">
+                              <input
+                                type="number"
+                                step={line.step ?? (line.isPercent ? 0.01 : 1000)}
+                                value={line.isPercent ? value : value || 0}
+                                onChange={handleBudgetChange(numericYear, line.key)}
+                                className={`${numberInputClasses} min-w-[12rem] text-right ${
+                                  isReadOnly ? readOnlyClasses : ""
+                                }`}
+                                disabled={isReadOnly || line.isReadOnly}
+                              />
+                          </td>
+                        );
+                      }
+
+                      return (
+                        <td key={year} className="px-4 py-3 text-right text-slate-700">
+                          {formatDisplay(value, { compact: true, maximumFractionDigits: 1 })}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OperatingBudgetView;

--- a/src/components/financial-modeling/views/ProFormaView.js
+++ b/src/components/financial-modeling/views/ProFormaView.js
@@ -1,0 +1,369 @@
+import React, { useMemo } from "react";
+import {
+  formatCurrency,
+  formatPercent,
+  formatCoverageRatio,
+} from "../../../utils/financialModeling";
+import { ShieldCheck, CircleDollarSign, PiggyBank, LineChart, Clock } from "lucide-react";
+
+const INDENT_CLASS_MAP = {
+  0: "pl-6",
+  1: "pl-10",
+  2: "pl-14",
+};
+
+const SummaryCard = ({ title, value, description, icon: Icon, highlight = false }) => (
+  <div
+    className={`flex items-start justify-between rounded-lg border border-slate-200 bg-white p-4 shadow-sm ${
+      highlight ? "ring-1 ring-blue-500" : ""
+    }`}
+  >
+    <div>
+      <p className="text-sm font-medium text-slate-500">{title}</p>
+      <p className="mt-2 text-xl font-semibold text-slate-900">{value}</p>
+      {description ? <p className="mt-1 text-xs text-slate-500">{description}</p> : null}
+    </div>
+    <div className="rounded-full bg-blue-50 p-2 text-blue-600">
+      <Icon size={20} />
+    </div>
+  </div>
+);
+
+const formatDaysCash = (value) => {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  const rounded = Math.round(value);
+  return `${Number.isFinite(rounded) ? rounded.toLocaleString() : "0"} days`;
+};
+
+const ProFormaView = ({ forecastResult, financialConfig }) => {
+  const { forecast = [], totals = {} } = forecastResult || {};
+
+  const years = useMemo(() => forecast.map((row) => row.year), [forecast]);
+  const forecastByYear = useMemo(() => {
+    const map = new Map();
+    forecast.forEach((row) => {
+      if (row && row.year !== undefined && row.year !== null) {
+        map.set(row.year, row);
+      }
+    });
+    return map;
+  }, [forecast]);
+
+  const summaryCards = useMemo(
+    () => [
+      {
+        title: "Ending Cash Balance",
+        value: formatCurrency(totals.endingCashBalance),
+        description: "Projected reserve level after capital delivery and debt obligations.",
+        icon: ShieldCheck,
+      },
+      {
+        title: "Total Capital Spend",
+        value: formatCurrency(totals.totalCapitalSpend),
+        description: "CIP investment flowing through the model horizon.",
+        icon: CircleDollarSign,
+      },
+      {
+        title: "New Debt Issued",
+        value: formatCurrency(totals.totalDebtIssued),
+        description: "Principal financed via bonds or loans from the CIP portfolio.",
+        icon: PiggyBank,
+      },
+      {
+        title: "Minimum Coverage Ratio",
+        value: totals.minCoverageRatio !== null ? formatCoverageRatio(totals.minCoverageRatio, 2) : "No Debt",
+        description:
+          totals.maxAdditionalRateIncrease > 0
+            ? `${formatPercent(totals.maxAdditionalRateIncrease, { decimals: 1 })} additional rate action may be required.`
+            : "Coverage targets are satisfied across the horizon.",
+        icon: LineChart,
+        highlight:
+          totals.maxAdditionalRateIncrease > 0 ||
+          (Number.isFinite(totals.minCoverageRatio) &&
+            totals.minCoverageRatio < financialConfig.targetCoverageRatio),
+      },
+      {
+        title: "Min Days Cash on Hand",
+        value: formatDaysCash(totals.minDaysCashOnHand),
+        description: "Liquidity cushion calculated from ending cash versus operating expenses.",
+        icon: Clock,
+        highlight:
+          Number.isFinite(totals.minDaysCashOnHand) && totals.minDaysCashOnHand < 180,
+      },
+    ],
+    [totals, financialConfig.targetCoverageRatio]
+  );
+
+  const proFormaRows = useMemo(
+    () => [
+      { type: "section", label: "Operating Revenues" },
+      {
+        key: "baseOperatingRevenue",
+        label: "Base Operating Revenue",
+        getValue: (row) => row.baseOperatingRevenue,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "plannedRateIncreasePercent",
+        label: "Planned Rate Adjustment",
+        getValue: (row) => row.plannedRateIncreasePercent,
+        formatter: (value) => formatPercent(value, { decimals: 1 }),
+        indentLevel: 1,
+      },
+      {
+        key: "adjustedOperatingRevenue",
+        label: "Adjusted Operating Revenue",
+        getValue: (row) => row.adjustedOperatingRevenue,
+        formatter: (value) => formatCurrency(value),
+        highlight: true,
+        indentLevel: 1,
+      },
+      {
+        key: "nonOperatingRevenue",
+        label: "Non-Operating Revenue",
+        getValue: (row) => row.nonOperatingRevenue,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "totalRevenue",
+        label: "Total Revenues",
+        getValue: (row) =>
+          (row.adjustedOperatingRevenue || 0) + (row.nonOperatingRevenue || 0),
+        formatter: (value) => formatCurrency(value),
+        isSubtotal: true,
+      },
+      { type: "section", label: "Operating Expenses" },
+      {
+        key: "omExpenses",
+        label: "Operations & Maintenance",
+        getValue: (row) => row.omExpenses,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "salaries",
+        label: "Salaries & Wages",
+        getValue: (row) => row.salaries,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "adminExpenses",
+        label: "Administration",
+        getValue: (row) => row.adminExpenses,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "totalOperatingExpenses",
+        label: "Total Operating Expenses",
+        getValue: (row) => row.totalOperatingExpenses,
+        formatter: (value) => formatCurrency(value),
+        isSubtotal: true,
+      },
+      { type: "section", label: "Net Position Before Debt" },
+      {
+        key: "netRevenueBeforeDebt",
+        label: "Net Revenue Before Debt",
+        getValue: (row) => row.netRevenueBeforeDebt,
+        formatter: (value) => formatCurrency(value),
+        highlight: true,
+        isSubtotal: true,
+      },
+      { type: "section", label: "Debt Service" },
+      {
+        key: "existingDebtService",
+        label: "Existing Debt Service",
+        getValue: (row) => row.existingDebtService,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "newDebtService",
+        label: "New Debt Service",
+        getValue: (row) => row.newDebtService,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "totalDebtService",
+        label: "Total Debt Service",
+        getValue: (row) => row.totalDebtService,
+        formatter: (value) => formatCurrency(value),
+        isSubtotal: true,
+      },
+      {
+        key: "netAfterDebt",
+        label: "Net After Debt Service",
+        getValue: (row) =>
+          (row.netRevenueBeforeDebt || 0) - (row.totalDebtService || 0),
+        formatter: (value) => formatCurrency(value),
+        highlight: true,
+        isSubtotal: true,
+      },
+      { type: "section", label: "Capital & Coverage" },
+      {
+        key: "cashFundedCapex",
+        label: "Cash-Funded CIP",
+        getValue: (row) => row.cashFundedCapex,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "cipSpend",
+        label: "Total CIP Spend",
+        getValue: (row) => row.cipSpend,
+        formatter: (value) => formatCurrency(value),
+        indentLevel: 1,
+      },
+      {
+        key: "endingCashBalance",
+        label: "Ending Cash Balance",
+        getValue: (row) => row.endingCashBalance,
+        formatter: (value) => formatCurrency(value),
+        highlight: true,
+        isSubtotal: true,
+      },
+      {
+        key: "daysCashOnHand",
+        label: "Days Cash on Hand",
+        getValue: (row) => row.daysCashOnHand,
+        formatter: (value) => formatDaysCash(value),
+        minThreshold: 180,
+      },
+      {
+        key: "coverageRatio",
+        label: "Debt Service Coverage",
+        getValue: (row) => row.coverageRatio,
+        formatter: (value) => formatCoverageRatio(value, 2),
+        emphasizeThreshold: financialConfig.targetCoverageRatio,
+      },
+      {
+        key: "additionalRateIncreaseNeeded",
+        label: "Additional Rate Increase Needed",
+        getValue: (row) => row.additionalRateIncreaseNeeded,
+        formatter: (value) =>
+          value && value > 0
+            ? formatPercent(value, { decimals: 1 })
+            : "Met",
+      },
+    ],
+    [financialConfig.targetCoverageRatio]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {summaryCards.map((card) => (
+          <SummaryCard key={card.title} {...card} />
+        ))}
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900">Utility Pro Forma Statement</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              Statement-style presentation of revenues, expenses, debt service, and ending cash balances across
+              the fiscal horizon.
+            </p>
+          </div>
+          <div className="text-sm text-slate-500">
+            Projection Window: FY {financialConfig.startYear} – FY
+            {" "}
+            {financialConfig.startYear + financialConfig.projectionYears - 1}
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="w-72 px-6 py-3 text-left font-semibold text-slate-600">Metric</th>
+                {years.map((year) => (
+                  <th key={year} className="px-4 py-3 text-right font-semibold text-slate-600">
+                    FY {year}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {proFormaRows.map((row) => {
+                if (row.type === "section") {
+                  return (
+                    <tr key={row.label} className="bg-slate-50/60">
+                      <th
+                        colSpan={1 + years.length}
+                        className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500"
+                      >
+                        {row.label}
+                      </th>
+                    </tr>
+                  );
+                }
+
+                const indentClass = INDENT_CLASS_MAP[row.indentLevel || 0] || INDENT_CLASS_MAP[0];
+                const borderClass = row.isSubtotal ? "border-t border-slate-200" : "";
+                const labelWeight = row.highlight || row.isSubtotal ? "font-semibold" : "font-medium";
+                const labelClasses = `py-3 pr-4 text-left text-sm ${labelWeight} text-slate-900 ${indentClass} ${borderClass}`;
+
+                return (
+                  <tr key={row.key}>
+                    <th scope="row" className={labelClasses}>
+                      {row.label}
+                    </th>
+                    {years.map((year) => {
+                      const yearData = forecastByYear.get(year) || {};
+                      const rawValue = row.getValue ? row.getValue(yearData) : yearData[row.key];
+                      const displayValue = row.formatter
+                        ? row.formatter(rawValue, yearData)
+                        : rawValue;
+
+                      let cellClass = `px-4 py-3 text-right font-mono text-sm text-slate-700 ${borderClass}`;
+                      if (row.highlight) {
+                        cellClass = `px-4 py-3 text-right font-mono text-sm font-semibold text-slate-900 ${borderClass}`;
+                      }
+
+                      if (
+                        row.key === "coverageRatio" &&
+                        row.emphasizeThreshold &&
+                        Number.isFinite(rawValue) &&
+                        rawValue < row.emphasizeThreshold
+                      ) {
+                        cellClass = `px-4 py-3 text-right font-mono text-sm font-semibold text-red-600 ${borderClass}`;
+                      } else if (
+                        row.key === "additionalRateIncreaseNeeded" &&
+                        Number(rawValue) > 0
+                      ) {
+                        cellClass = `px-4 py-3 text-right font-mono text-sm font-medium text-amber-600 ${borderClass}`;
+                      } else if (
+                        row.minThreshold !== undefined &&
+                        row.minThreshold !== null &&
+                        Number.isFinite(rawValue) &&
+                        rawValue < row.minThreshold
+                      ) {
+                        cellClass = `px-4 py-3 text-right font-mono text-sm font-semibold text-red-600 ${borderClass}`;
+                      }
+
+                      return (
+                        <td key={year} className={cellClass}>
+                          {displayValue}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProFormaView;

--- a/src/components/financial-modeling/views/SettingsView.js
+++ b/src/components/financial-modeling/views/SettingsView.js
@@ -1,0 +1,219 @@
+import React, { useMemo } from "react";
+import { formatCurrency } from "../../../utils/financialModeling";
+
+const numberInputClasses =
+  "w-full rounded-md border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200";
+const readOnlyClasses = "bg-slate-100 text-slate-500 cursor-not-allowed";
+
+const SettingsView = ({
+  financialConfig = {},
+  projectTypeSummaries = [],
+  utilityOptions = [],
+  onUpdateProjectTypeUtility,
+  onUpdateFinancialConfig,
+  isReadOnly,
+}) => {
+  const assignmentOptions = useMemo(
+    () => [{ value: "", label: "Unassigned" }, ...utilityOptions],
+    [utilityOptions]
+  );
+
+  const handleConfigChange = (field) => (event) => {
+    if (isReadOnly) {
+      return;
+    }
+
+    const rawValue = event.target.value;
+    let parsedValue = rawValue;
+
+    if (field === "startYear" || field === "projectionYears") {
+      parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        parsedValue = financialConfig[field] || 0;
+      }
+      parsedValue = Math.max(field === "projectionYears" ? 1 : 1900, Math.round(parsedValue));
+    } else if (field === "startingCashBalance") {
+      parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        parsedValue = financialConfig.startingCashBalance || 0;
+      }
+      parsedValue = Math.max(0, parsedValue);
+    } else if (field === "targetCoverageRatio") {
+      parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        parsedValue = financialConfig.targetCoverageRatio || 1;
+      }
+      parsedValue = Math.max(0, parsedValue);
+    }
+
+    onUpdateFinancialConfig?.({ [field]: parsedValue });
+  };
+
+  const configItems = useMemo(
+    () => [
+      {
+        label: "Start Year",
+        value: financialConfig.startYear ? `FY ${financialConfig.startYear}` : "—",
+      },
+      {
+        label: "Projection Horizon",
+        value:
+          financialConfig.projectionYears && Number(financialConfig.projectionYears) > 0
+            ? `${financialConfig.projectionYears} Years`
+            : "—",
+      },
+      {
+        label: "Starting Cash Balance",
+        value: formatCurrency(financialConfig.startingCashBalance || 0),
+      },
+      {
+        label: "Target Coverage Ratio",
+        value:
+          financialConfig.targetCoverageRatio !== undefined && financialConfig.targetCoverageRatio !== null
+            ? `${Number(financialConfig.targetCoverageRatio).toFixed(2)}x`
+            : "—",
+      },
+    ],
+    [financialConfig]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-slate-900">Projection Settings</h3>
+        <p className="mt-1 text-sm text-slate-600">
+          Configure the fiscal window, opening reserves, and policy targets that guide every pro forma scenario.
+        </p>
+
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <label className="text-sm font-medium text-slate-700">
+            <span>Start Fiscal Year</span>
+            <input
+              type="number"
+              value={financialConfig.startYear}
+              onChange={handleConfigChange("startYear")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={1900}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            <span>Projection Years</span>
+            <input
+              type="number"
+              value={financialConfig.projectionYears}
+              onChange={handleConfigChange("projectionYears")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={1}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            <span>Starting Cash Balance</span>
+            <input
+              type="number"
+              value={financialConfig.startingCashBalance}
+              onChange={handleConfigChange("startingCashBalance")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={0}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            <span>Target Coverage Ratio</span>
+            <input
+              type="number"
+              step="0.01"
+              value={financialConfig.targetCoverageRatio}
+              onChange={handleConfigChange("targetCoverageRatio")}
+              className={`${numberInputClasses} mt-1 ${isReadOnly ? readOnlyClasses : ""}`}
+              disabled={isReadOnly}
+              min={0}
+            />
+          </label>
+        </div>
+
+        <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {configItems.map((item) => (
+            <div key={item.label} className="rounded-md bg-slate-50 px-4 py-3">
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{item.label}</dt>
+              <dd className="mt-1 text-sm font-medium text-slate-800">{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900">Project Type Utility Assignments</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              Map each project type to the appropriate utility enterprise fund. Assignments control which projects feed the
+              CIP, spend plan, and pro forma for each utility portfolio.
+            </p>
+          </div>
+          <div className="text-sm text-slate-500">
+            {projectTypeSummaries.length} project types available for assignment
+          </div>
+        </div>
+
+        {projectTypeSummaries.length === 0 ? (
+          <p className="mt-4 text-sm text-slate-500">
+            No project types are defined yet. Create project categories in the planning workspace to enable utility
+            mapping.
+          </p>
+        ) : (
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200 text-sm">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">Project Type</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">Projects in CIP</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">Assigned Utility</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {projectTypeSummaries.map((summary) => {
+                  const currentValue =
+                    summary.assignedUtility === null || summary.assignedUtility === undefined
+                      ? ""
+                      : summary.assignedUtility;
+
+                  return (
+                    <tr key={summary.id}>
+                      <th scope="row" className="px-4 py-3 text-left font-medium text-slate-900">
+                        {summary.name}
+                      </th>
+                      <td className="px-4 py-3 text-slate-600">{summary.projectCount}</td>
+                      <td className="px-4 py-3">
+                        <select
+                          value={currentValue}
+                          onChange={(event) =>
+                            onUpdateProjectTypeUtility?.(
+                              summary.id,
+                              event.target.value ? event.target.value : null
+                            )
+                          }
+                          className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                          disabled={isReadOnly}
+                        >
+                          {assignmentOptions.map((option) => (
+                            <option key={option.value || "none"} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsView;

--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../context/AuthContext';
 import { normalizeProjectBudgetBreakdown } from '../utils/projectBudgets';
+import {
+  sanitizeExistingDebtInstrumentList,
+  sanitizeExistingDebtManualTotals,
+} from '../utils/financialModeling';
 
 const toCamelCaseKey = (key) =>
   key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
@@ -168,6 +172,155 @@ const staffAssignmentToRow = (assignment, organizationId) => ({
   pm_hours: normalizeNullable(assignment.pmHours) ?? 0,
   design_hours: normalizeNullable(assignment.designHours) ?? 0,
   construction_hours: normalizeNullable(assignment.constructionHours) ?? 0,
+});
+
+const UTILITY_KEYS = new Set(['water', 'sewer', 'power', 'gas', 'stormwater']);
+
+const normalizeUtilityKey = (value) => {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return UTILITY_KEYS.has(normalized) ? normalized : null;
+};
+
+const sanitizeFinancialConfig = (rawConfig = {}) => {
+  const currentYear = new Date().getFullYear();
+  const startYear = Number(rawConfig.startYear);
+  const projectionYears = Number(rawConfig.projectionYears);
+  const startingCashBalance = Number(rawConfig.startingCashBalance);
+  const targetCoverageRatio = Number(rawConfig.targetCoverageRatio);
+
+  return {
+    startYear: Number.isFinite(startYear) ? startYear : currentYear,
+    projectionYears: Number.isFinite(projectionYears) && projectionYears > 0
+      ? Math.round(projectionYears)
+      : 10,
+    startingCashBalance: Number.isFinite(startingCashBalance) ? startingCashBalance : 0,
+    targetCoverageRatio: Number.isFinite(targetCoverageRatio) ? targetCoverageRatio : 1.5,
+  };
+};
+
+const sanitizeBudgetEscalations = (rawEscalations = {}) => ({
+  operatingRevenue: Number(rawEscalations.operatingRevenue) || 0,
+  nonOperatingRevenue: Number(rawEscalations.nonOperatingRevenue) || 0,
+  omExpenses: Number(rawEscalations.omExpenses) || 0,
+  salaries: Number(rawEscalations.salaries) || 0,
+  adminExpenses: Number(rawEscalations.adminExpenses) || 0,
+  existingDebtService: Number(rawEscalations.existingDebtService) || 0,
+});
+
+const utilityProfileFromRow = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    utilityKey: normalizeUtilityKey(row.utility_key),
+    financialConfig: sanitizeFinancialConfig(parseJsonField(row.financial_config, {})),
+    budgetEscalations: sanitizeBudgetEscalations(parseJsonField(row.budget_escalations, {})),
+    existingDebtManualTotals: sanitizeExistingDebtManualTotals(
+      parseJsonField(row.existing_debt_manual_totals, {})
+    ),
+    existingDebtInstruments: sanitizeExistingDebtInstrumentList(
+      parseJsonField(row.existing_debt_instruments, [])
+    ),
+  };
+};
+
+const utilityProfileToRow = (organizationId, utilityKey, profile = {}) => {
+  const normalizedKey = normalizeUtilityKey(utilityKey);
+  const financialConfig = sanitizeFinancialConfig(profile.financialConfig || {});
+  const budgetEscalations = sanitizeBudgetEscalations(profile.budgetEscalations || {});
+  const manualTotals = sanitizeExistingDebtManualTotals(
+    profile.existingDebtManualTotals || {}
+  );
+  const instruments = sanitizeExistingDebtInstrumentList(
+    profile.existingDebtInstruments || []
+  );
+
+  return {
+    organization_id: organizationId,
+    utility_key: normalizedKey,
+    financial_config: JSON.stringify(financialConfig),
+    budget_escalations: JSON.stringify(budgetEscalations),
+    existing_debt_manual_totals: JSON.stringify(manualTotals),
+    existing_debt_instruments: JSON.stringify(instruments),
+  };
+};
+
+const operatingBudgetFromRow = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    year: Number(row.fiscal_year),
+    operatingRevenue: Number(row.operating_revenue) || 0,
+    nonOperatingRevenue: Number(row.non_operating_revenue) || 0,
+    omExpenses: Number(row.om_expenses) || 0,
+    salaries: Number(row.salaries) || 0,
+    adminExpenses: Number(row.admin_expenses) || 0,
+    existingDebtService: Number(row.existing_debt_service) || 0,
+    rateIncreasePercent: Number(row.rate_increase_percent) || 0,
+  };
+};
+
+const operatingBudgetToRow = (organizationId, utilityKey, row) => ({
+  organization_id: organizationId,
+  utility_key: normalizeUtilityKey(utilityKey),
+  fiscal_year: Number(row.year),
+  operating_revenue: normalizeNullable(row.operatingRevenue) ?? 0,
+  non_operating_revenue: normalizeNullable(row.nonOperatingRevenue) ?? 0,
+  om_expenses: normalizeNullable(row.omExpenses) ?? 0,
+  salaries: normalizeNullable(row.salaries) ?? 0,
+  admin_expenses: normalizeNullable(row.adminExpenses) ?? 0,
+  existing_debt_service: normalizeNullable(row.existingDebtService) ?? 0,
+  rate_increase_percent: normalizeNullable(row.rateIncreasePercent) ?? 0,
+});
+
+const projectTypeUtilityFromRow = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    projectTypeId: row.project_type_id,
+    utilityKey: normalizeUtilityKey(row.utility_key),
+  };
+};
+
+const projectTypeUtilityToRow = (organizationId, projectTypeId, utilityKey) => ({
+  organization_id: organizationId,
+  project_type_id: projectTypeId,
+  utility_key: normalizeUtilityKey(utilityKey),
+});
+
+const fundingAssumptionFromRow = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    fundingSourceId: row.funding_source_id,
+    sourceName: row.source_name || '',
+    financingType: row.financing_type || 'cash',
+    interestRate: Number(row.interest_rate) || 0,
+    termYears: Number(row.term_years) || 0,
+  };
+};
+
+const fundingAssumptionToRow = (organizationId, assumption) => ({
+  organization_id: organizationId,
+  funding_source_id: assumption.fundingSourceId,
+  source_name: assumption.sourceName || null,
+  financing_type: assumption.financingType || 'cash',
+  interest_rate: normalizeNullable(assumption.interestRate) ?? 0,
+  term_years: normalizeNullable(assumption.termYears) ?? 0,
 });
 
 const buildErrorMessage = (error, fallback) =>
@@ -925,6 +1078,250 @@ export const useDatabase = (defaultData = {}) => {
     [organizationId, assertReady, assertCanEdit]
   );
 
+  const getUtilityProfiles = useCallback(async () => {
+    assertReady();
+
+    const { data, error: fetchError } = await supabase
+      .from('utility_financial_profiles')
+      .select('*')
+      .eq('organization_id', organizationId);
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    const profiles = {};
+    (data || []).forEach((row) => {
+      const parsed = utilityProfileFromRow(row);
+      if (parsed?.utilityKey) {
+        profiles[parsed.utilityKey] = parsed;
+      }
+    });
+
+    return profiles;
+  }, [organizationId, assertReady]);
+
+  const saveUtilityProfile = useCallback(
+    async (utilityKey, profile) => {
+      assertReady();
+      assertCanEdit();
+
+      const normalizedKey = normalizeUtilityKey(utilityKey);
+      if (!normalizedKey) {
+        throw new Error('A valid utility key is required.');
+      }
+
+      const payload = utilityProfileToRow(organizationId, normalizedKey, profile);
+      const { data, error: upsertError } = await supabase
+        .from('utility_financial_profiles')
+        .upsert(payload, { onConflict: 'organization_id,utility_key' })
+        .select()
+        .single();
+
+      if (upsertError) {
+        throw upsertError;
+      }
+
+      return utilityProfileFromRow(data);
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
+  const getUtilityOperatingBudgets = useCallback(async () => {
+    assertReady();
+
+    const { data, error: fetchError } = await supabase
+      .from('utility_operating_budgets')
+      .select('*')
+      .eq('organization_id', organizationId)
+      .order('fiscal_year', { ascending: true });
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    const budgets = new Map();
+    (data || []).forEach((row) => {
+      const utilityKey = normalizeUtilityKey(row.utility_key);
+      const parsedRow = operatingBudgetFromRow(row);
+      if (!utilityKey || !parsedRow) {
+        return;
+      }
+      if (!budgets.has(utilityKey)) {
+        budgets.set(utilityKey, []);
+      }
+      budgets.get(utilityKey).push(parsedRow);
+    });
+
+    return budgets;
+  }, [organizationId, assertReady]);
+
+  const upsertUtilityOperatingBudgetRows = useCallback(
+    async (utilityKey, rows) => {
+      if (!rows || !rows.length) {
+        return;
+      }
+
+      assertReady();
+      assertCanEdit();
+
+      const payload = rows
+        .filter((row) => Number.isFinite(Number(row?.year)))
+        .map((row) => operatingBudgetToRow(organizationId, utilityKey, row));
+
+      if (!payload.length) {
+        return;
+      }
+
+      const { error: upsertError } = await supabase
+        .from('utility_operating_budgets')
+        .upsert(payload, { onConflict: 'organization_id,utility_key,fiscal_year' });
+
+      if (upsertError) {
+        throw upsertError;
+      }
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
+  const deleteUtilityOperatingBudgetsNotIn = useCallback(
+    async (utilityKey, yearsToKeep = []) => {
+      assertReady();
+      assertCanEdit();
+
+      const normalizedKey = normalizeUtilityKey(utilityKey);
+      if (!normalizedKey) {
+        return;
+      }
+
+      let query = supabase
+        .from('utility_operating_budgets')
+        .delete()
+        .eq('organization_id', organizationId)
+        .eq('utility_key', normalizedKey);
+
+      const sanitizedYears = (yearsToKeep || [])
+        .map((value) => Number(value))
+        .filter((value) => Number.isFinite(value));
+
+      if (sanitizedYears.length > 0) {
+        query = query.not('fiscal_year', 'in', `(${sanitizedYears.join(',')})`);
+      }
+
+      const { error: deleteError } = await query;
+
+      if (deleteError) {
+        throw deleteError;
+      }
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
+  const getProjectTypeUtilities = useCallback(async () => {
+    assertReady();
+
+    const { data, error: fetchError } = await supabase
+      .from('project_type_utilities')
+      .select('*')
+      .eq('organization_id', organizationId);
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    const assignments = {};
+    (data || []).forEach((row) => {
+      const parsed = projectTypeUtilityFromRow(row);
+      if (!parsed?.projectTypeId) {
+        return;
+      }
+      assignments[String(parsed.projectTypeId)] = parsed.utilityKey || null;
+    });
+
+    return assignments;
+  }, [organizationId, assertReady]);
+
+  const saveProjectTypeUtility = useCallback(
+    async (projectTypeId, utilityKey) => {
+      assertReady();
+      assertCanEdit();
+
+      if (!projectTypeId) {
+        throw new Error('Project type id is required.');
+      }
+
+      const normalizedKey = normalizeUtilityKey(utilityKey);
+
+      if (!normalizedKey) {
+        const { error: deleteError } = await supabase
+          .from('project_type_utilities')
+          .delete()
+          .eq('organization_id', organizationId)
+          .eq('project_type_id', projectTypeId);
+
+        if (deleteError) {
+          throw deleteError;
+        }
+
+        return null;
+      }
+
+      const payload = projectTypeUtilityToRow(organizationId, projectTypeId, normalizedKey);
+      const { data, error: upsertError } = await supabase
+        .from('project_type_utilities')
+        .upsert(payload, { onConflict: 'organization_id,project_type_id' })
+        .select()
+        .single();
+
+      if (upsertError) {
+        throw upsertError;
+      }
+
+      return projectTypeUtilityFromRow(data);
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
+  const getFundingSourceAssumptions = useCallback(async () => {
+    assertReady();
+
+    const { data, error: fetchError } = await supabase
+      .from('funding_source_financing_assumptions')
+      .select('*')
+      .eq('organization_id', organizationId);
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    return (data || []).map(fundingAssumptionFromRow).filter(Boolean);
+  }, [organizationId, assertReady]);
+
+  const saveFundingSourceAssumption = useCallback(
+    async (assumption) => {
+      assertReady();
+      assertCanEdit();
+
+      if (!assumption || !assumption.fundingSourceId) {
+        throw new Error('A funding source id is required.');
+      }
+
+      const payload = fundingAssumptionToRow(organizationId, assumption);
+      const { data, error: upsertError } = await supabase
+        .from('funding_source_financing_assumptions')
+        .upsert(payload, { onConflict: 'organization_id,funding_source_id' })
+        .select()
+        .single();
+
+      if (upsertError) {
+        throw upsertError;
+      }
+
+      return fundingAssumptionFromRow(data);
+    },
+    [organizationId, assertReady, assertCanEdit]
+  );
+
   const exportDatabase = useCallback(async () => {
     assertReady();
 
@@ -992,6 +1389,15 @@ export const useDatabase = (defaultData = {}) => {
       saveStaffAssignment,
       getStaffAssignments,
       deleteStaffAssignment,
+      getUtilityProfiles,
+      saveUtilityProfile,
+      getUtilityOperatingBudgets,
+      upsertUtilityOperatingBudgetRows,
+      deleteUtilityOperatingBudgetsNotIn,
+      getProjectTypeUtilities,
+      saveProjectTypeUtility,
+      getFundingSourceAssumptions,
+      saveFundingSourceAssumption,
       exportDatabase,
       importDatabase,
     }),
@@ -1020,6 +1426,15 @@ export const useDatabase = (defaultData = {}) => {
       saveStaffAssignment,
       getStaffAssignments,
       deleteStaffAssignment,
+      getUtilityProfiles,
+      saveUtilityProfile,
+      getUtilityOperatingBudgets,
+      upsertUtilityOperatingBudgetRows,
+      deleteUtilityOperatingBudgetsNotIn,
+      getProjectTypeUtilities,
+      saveProjectTypeUtility,
+      getFundingSourceAssumptions,
+      saveFundingSourceAssumption,
       exportDatabase,
       importDatabase,
     ]

--- a/src/utils/effortTemplates.js
+++ b/src/utils/effortTemplates.js
@@ -1,0 +1,184 @@
+const toNumber = (value, { allowNegative = false } = {}) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+
+  if (!allowNegative && numeric < 0) {
+    return 0;
+  }
+
+  return numeric;
+};
+
+const toNullableId = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) ? numeric : trimmed;
+  }
+
+  return null;
+};
+
+const sanitizePhaseDurations = (input = {}) => {
+  const source =
+    input && typeof input === 'object'
+      ? input
+      : {
+          pm: input?.pmDuration ?? input?.pmMonths,
+          design: input?.designDuration ?? input?.designMonths,
+          construction: input?.constructionDuration ?? input?.constructionMonths,
+        };
+
+  return {
+    pm: toNumber(
+      source.pm ?? source.pmDuration ?? source.pmMonths ?? input.pmDuration
+    ),
+    design: toNumber(
+      source.design ?? source.designDuration ?? source.designMonths ?? input.designDuration
+    ),
+    construction: toNumber(
+      source.construction ??
+        source.constructionDuration ??
+        source.constructionMonths ??
+        input.constructionDuration
+    ),
+  };
+};
+
+const sanitizePhaseHours = (input = {}) => {
+  const source =
+    input && typeof input === 'object'
+      ? input
+      : {
+          pmHours: input.pmHours ?? input.pm,
+          designHours: input.designHours ?? input.design,
+          constructionHours: input.constructionHours ?? input.construction,
+        };
+
+  return {
+    pmHours: toNumber(
+      source.pmHours ?? source.pm ?? input.pmHours ?? input.pm
+    ),
+    designHours: toNumber(
+      source.designHours ?? source.design ?? input.designHours ?? input.design
+    ),
+    constructionHours: toNumber(
+      source.constructionHours ??
+        source.construction ??
+        input.constructionHours ??
+        input.construction
+    ),
+  };
+};
+
+const sanitizeCategoryHours = (input = {}) => {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+
+  const normalized = {};
+
+  Object.entries(input).forEach(([categoryId, values]) => {
+    const key = toNullableId(categoryId);
+    if (!key) {
+      return;
+    }
+
+    const hours = sanitizePhaseHours(values);
+    if (hours.pmHours || hours.designHours || hours.constructionHours) {
+      normalized[key] = hours;
+    }
+  });
+
+  return normalized;
+};
+
+const sanitizeTimestamp = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+};
+
+export const normalizeEffortTemplate = (template = {}) => {
+  if (!template || typeof template !== 'object') {
+    return {
+      id: null,
+      name: '',
+      description: '',
+      templateType: 'project',
+      projectTypeId: null,
+      defaultPhaseDurations: { pm: 0, design: 0, construction: 0 },
+      defaultPhaseHours: { pmHours: 0, designHours: 0, constructionHours: 0 },
+      hoursByCategory: {},
+      notes: '',
+      createdAt: null,
+      updatedAt: null,
+    };
+  }
+
+  const defaultPhaseDurations = sanitizePhaseDurations(
+    template.defaultPhaseDurations ??
+      template.phaseDurations ??
+      template.defaultDurations ??
+      template
+  );
+
+  const defaultPhaseHours = sanitizePhaseHours(
+    template.defaultPhaseHours ??
+      template.defaultHours ??
+      template.hours ??
+      template
+  );
+
+  const hoursByCategory = sanitizeCategoryHours(
+    template.hoursByCategory ??
+      template.categoryHours ??
+      template.continuousHoursByCategory ??
+      {}
+  );
+
+  const name =
+    typeof template.name === 'string' ? template.name.trim() : '';
+  const description =
+    typeof template.description === 'string' ? template.description.trim() : '';
+  const notes = typeof template.notes === 'string' ? template.notes.trim() : '';
+
+  const templateType =
+    template.templateType === 'program' || template.templateType === 'programmatic'
+      ? 'program'
+      : 'project';
+
+  return {
+    ...template,
+    id: toNullableId(template.id),
+    projectTypeId: toNullableId(template.projectTypeId),
+    templateType,
+    name,
+    description,
+    notes,
+    defaultPhaseDurations,
+    defaultPhaseHours,
+    defaultHours: defaultPhaseHours,
+    phaseDurations: defaultPhaseDurations,
+    hoursByCategory,
+    createdAt: sanitizeTimestamp(template.createdAt ?? template.created_at),
+    updatedAt: sanitizeTimestamp(template.updatedAt ?? template.updated_at),
+  };
+};

--- a/src/utils/financialModeling.js
+++ b/src/utils/financialModeling.js
@@ -1,0 +1,1258 @@
+const sanitizeNumber = (value, fallback = 0) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const sanitizePositiveInteger = (value, fallback = 0) => {
+  const numeric = parseInt(value, 10);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+};
+
+const sanitizePercent = (value, fallback = 0) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const cloneBudgetRow = (year, template) => ({
+  year,
+  operatingRevenue: sanitizeNumber(template?.operatingRevenue),
+  nonOperatingRevenue: sanitizeNumber(template?.nonOperatingRevenue),
+  omExpenses: sanitizeNumber(template?.omExpenses),
+  salaries: sanitizeNumber(template?.salaries),
+  adminExpenses: sanitizeNumber(template?.adminExpenses),
+  existingDebtService: sanitizeNumber(template?.existingDebtService),
+  rateIncreasePercent: sanitizePercent(template?.rateIncreasePercent),
+});
+
+export const generateDefaultOperatingBudget = (startYear, years = 5) => {
+  const baseYear = sanitizePositiveInteger(startYear, new Date().getFullYear());
+  const totalYears = Math.max(1, sanitizePositiveInteger(years, 5));
+  const rows = [];
+
+  for (let i = 0; i < totalYears; i += 1) {
+    rows.push(
+      cloneBudgetRow(baseYear + i, {
+        operatingRevenue: 0,
+        nonOperatingRevenue: 0,
+        omExpenses: 0,
+        salaries: 0,
+        adminExpenses: 0,
+        existingDebtService: 0,
+        rateIncreasePercent: 0,
+      })
+    );
+  }
+
+  return rows;
+};
+
+export const ensureBudgetYears = (rows, startYear, projectionYears) => {
+  const desiredStart = sanitizePositiveInteger(
+    startYear,
+    new Date().getFullYear()
+  );
+  const yearsNeeded = Math.max(1, sanitizePositiveInteger(projectionYears, 1));
+  const existingMap = new Map();
+
+  (rows || []).forEach((row) => {
+    if (row && Number.isFinite(row.year)) {
+      existingMap.set(Number(row.year), { ...row, year: Number(row.year) });
+    }
+  });
+
+  const result = [];
+  let lastTemplate = null;
+
+  for (let offset = 0; offset < yearsNeeded; offset += 1) {
+    const year = desiredStart + offset;
+    if (existingMap.has(year)) {
+      const existing = existingMap.get(year);
+      result.push({
+        ...existing,
+        year,
+      });
+      lastTemplate = existing;
+    } else {
+      const template = lastTemplate || existingMap.get(year - 1);
+      result.push(cloneBudgetRow(year, template));
+      lastTemplate = template;
+    }
+  }
+
+  return result;
+};
+
+const FINANCING_TYPE_PRESETS = {
+  bond: {
+    interestRate: 4.25,
+    termYears: 25,
+  },
+  srf: {
+    interestRate: 2.0,
+    termYears: 30,
+  },
+  cash: {
+    interestRate: 0,
+    termYears: 0,
+  },
+  grant: {
+    interestRate: 0,
+    termYears: 0,
+  },
+};
+
+const inferFinancingType = (fundingSource) => {
+  if (!fundingSource || !fundingSource.name) {
+    return "cash";
+  }
+
+  const name = fundingSource.name.toLowerCase();
+
+  if (name.includes("bond")) {
+    return "bond";
+  }
+
+  if (name.includes("loan") || name.includes("srf") || name.includes("revolving")) {
+    return "srf";
+  }
+
+  if (name.includes("grant")) {
+    return "grant";
+  }
+
+  return "cash";
+};
+
+export const createDefaultFundingAssumption = (fundingSource) => {
+  const financingType = inferFinancingType(fundingSource);
+  const preset = FINANCING_TYPE_PRESETS[financingType] || FINANCING_TYPE_PRESETS.cash;
+
+  return {
+    fundingSourceId: fundingSource?.id ?? null,
+    sourceName: fundingSource?.name ?? "Unassigned Funding Source",
+    financingType,
+    interestRate: preset.interestRate,
+    termYears: preset.termYears,
+  };
+};
+
+export const generateDefaultFundingAssumptions = (fundingSources = []) => {
+  return (fundingSources || []).map((source) => createDefaultFundingAssumption(source));
+};
+
+const ensureYearEntry = (plan, year) => {
+  if (!plan[year]) {
+    plan[year] = {
+      designSpend: 0,
+      constructionSpend: 0,
+      programSpend: 0,
+      totalSpend: 0,
+      byFundingSource: {},
+    };
+  }
+  return plan[year];
+};
+
+const addSpend = (plan, year, amount, fundingSourceId, type) => {
+  if (!Number.isFinite(year) || !Number.isFinite(amount) || amount <= 0) {
+    return;
+  }
+  const yearEntry = ensureYearEntry(plan, year);
+  const fundingKey = fundingSourceId == null ? "unassigned" : String(fundingSourceId);
+  yearEntry.totalSpend += amount;
+  if (type === "design") {
+    yearEntry.designSpend += amount;
+  } else if (type === "construction") {
+    yearEntry.constructionSpend += amount;
+  } else if (type === "program") {
+    yearEntry.programSpend += amount;
+  }
+
+  yearEntry.byFundingSource[fundingKey] =
+    (yearEntry.byFundingSource[fundingKey] || 0) + amount;
+};
+
+const addToYearMap = (target, year, amount) => {
+  if (!Number.isFinite(year) || !Number.isFinite(amount)) {
+    return;
+  }
+
+  if (Math.abs(amount) < 1e-9) {
+    return;
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  target[year] = (target[year] || 0) + amount;
+};
+
+const allocateEvenMonthlySpend = (startDate, months, budget, fundingSourceId, plan, type) => {
+  const amount = sanitizeNumber(budget, 0);
+  const duration = Math.max(1, sanitizePositiveInteger(months, 1));
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return;
+  }
+
+  const start = startDate instanceof Date ? startDate : new Date(startDate);
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+    return;
+  }
+
+  const monthlySpend = amount / duration;
+  const cursor = new Date(start.getTime());
+
+  for (let i = 0; i < duration; i += 1) {
+    const year = cursor.getFullYear();
+    addSpend(plan, year, monthlySpend, fundingSourceId, type);
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+};
+
+const allocateProgramSpend = (project, plan) => {
+  const annualBudget = sanitizeNumber(project?.annualBudget, 0);
+  if (!annualBudget || annualBudget <= 0) {
+    return;
+  }
+
+  const start = project?.programStartDate
+    ? new Date(project.programStartDate)
+    : project?.designStart instanceof Date
+    ? project.designStart
+    : null;
+  const end = project?.programEndDate
+    ? new Date(project.programEndDate)
+    : project?.constructionEnd instanceof Date
+    ? project.constructionEnd
+    : null;
+
+  if (!start || Number.isNaN(start.getTime()) || !end || Number.isNaN(end.getTime())) {
+    return;
+  }
+
+  const monthlySpend = annualBudget / 12;
+  const cursor = new Date(start.getTime());
+  while (cursor <= end) {
+    const year = cursor.getFullYear();
+    addSpend(plan, year, monthlySpend, project?.fundingSourceId, "program");
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+};
+
+export const buildProjectSpendPlan = (projectTimelines = []) => {
+  const spendPlan = {};
+
+  (projectTimelines || []).forEach((project) => {
+    if (!project) {
+      return;
+    }
+
+    if (project.type === "program") {
+      allocateProgramSpend(project, spendPlan);
+      return;
+    }
+
+    const designBudget = sanitizeNumber(
+      project.designBudget ??
+        (project.totalBudget && project.designBudgetPercent
+          ? (project.totalBudget * project.designBudgetPercent) / 100
+          : 0),
+      0
+    );
+    const constructionBudget = sanitizeNumber(
+      project.constructionBudget ??
+        (project.totalBudget && project.constructionBudgetPercent
+          ? (project.totalBudget * project.constructionBudgetPercent) / 100
+          : 0),
+      0
+    );
+
+    if (designBudget > 0) {
+      const designDuration = Math.max(1, sanitizePositiveInteger(project.designDuration, 1));
+      const designStart = project.designStart || project.designStartDate;
+      allocateEvenMonthlySpend(
+        designStart,
+        designDuration,
+        designBudget,
+        project.fundingSourceId,
+        spendPlan,
+        "design"
+      );
+    }
+
+    if (constructionBudget > 0) {
+      const constructionDuration = Math.max(
+        1,
+        sanitizePositiveInteger(project.constructionDuration, 1)
+      );
+      const constructionStart = project.constructionStart || project.constructionStartDate;
+      allocateEvenMonthlySpend(
+        constructionStart,
+        constructionDuration,
+        constructionBudget,
+        project.fundingSourceId,
+        spendPlan,
+        "construction"
+      );
+    }
+  });
+
+  return spendPlan;
+};
+
+const normalizeDate = (value) => {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const allocateProjectSpend = (entry, startDate, months, budget) => {
+  const amount = sanitizeNumber(budget, 0);
+  const duration = Math.max(1, sanitizePositiveInteger(months, 1));
+
+  if (!(amount > 0)) {
+    return;
+  }
+
+  const start = normalizeDate(startDate);
+  if (!start) {
+    return;
+  }
+
+  const monthlySpend = amount / duration;
+  const cursor = new Date(start.getTime());
+
+  for (let index = 0; index < duration; index += 1) {
+    const year = cursor.getFullYear();
+    if (Number.isFinite(year)) {
+      entry.spendByYear[year] = (entry.spendByYear[year] || 0) + monthlySpend;
+      entry.totalSpend += monthlySpend;
+    }
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+};
+
+export const buildProjectSpendBreakdown = (projectTimelines = []) => {
+  const breakdown = [];
+
+  (projectTimelines || []).forEach((project) => {
+    if (!project) {
+      return;
+    }
+
+    const entry = {
+      projectId: project.id ?? null,
+      name: project.name || "Unnamed Project",
+      type: project.type || "project",
+      projectTypeId: project.projectTypeId ?? null,
+      fundingSourceId: project.fundingSourceId ?? null,
+      deliveryType: project.deliveryType || null,
+      designStart: normalizeDate(project.designStart) || normalizeDate(project.designStartDate),
+      designEnd: normalizeDate(project.designEnd) || null,
+      constructionStart:
+        normalizeDate(project.constructionStart) ||
+        normalizeDate(project.constructionStartDate),
+      constructionEnd: normalizeDate(project.constructionEnd) || null,
+      programStart: normalizeDate(project.programStartDate) || null,
+      programEnd: normalizeDate(project.programEndDate) || null,
+      spendByYear: {},
+      totalSpend: 0,
+    };
+
+    if (entry.type === "program") {
+      const start = entry.programStart || entry.designStart;
+      const end = entry.programEnd || entry.designEnd;
+      const annualBudget = sanitizeNumber(project.annualBudget, 0);
+
+      if (start && end && annualBudget > 0) {
+        const monthlySpend = annualBudget / 12;
+        const cursor = new Date(start.getTime());
+
+        while (cursor <= end) {
+          const year = cursor.getFullYear();
+          if (Number.isFinite(year)) {
+            entry.spendByYear[year] =
+              (entry.spendByYear[year] || 0) + monthlySpend;
+            entry.totalSpend += monthlySpend;
+          }
+          cursor.setMonth(cursor.getMonth() + 1);
+        }
+      }
+
+      breakdown.push(entry);
+      return;
+    }
+
+    const designBudget = sanitizeNumber(
+      project.designBudget ??
+        (project.totalBudget && project.designBudgetPercent
+          ? (project.totalBudget * project.designBudgetPercent) / 100
+          : 0),
+      0
+    );
+    const constructionBudget = sanitizeNumber(
+      project.constructionBudget ??
+        (project.totalBudget && project.constructionBudgetPercent
+          ? (project.totalBudget * project.constructionBudgetPercent) / 100
+          : 0),
+      0
+    );
+
+    if (!entry.designEnd && entry.designStart && project.designDuration) {
+      const designEnd = new Date(entry.designStart.getTime());
+      designEnd.setMonth(
+        designEnd.getMonth() + Math.max(0, sanitizePositiveInteger(project.designDuration, 0))
+      );
+      entry.designEnd = designEnd;
+    }
+
+    if (
+      !entry.constructionEnd &&
+      entry.constructionStart &&
+      project.constructionDuration
+    ) {
+      const constructionEnd = new Date(entry.constructionStart.getTime());
+      constructionEnd.setMonth(
+        constructionEnd.getMonth() +
+          Math.max(0, sanitizePositiveInteger(project.constructionDuration, 0))
+      );
+      entry.constructionEnd = constructionEnd;
+    }
+
+    if (designBudget > 0) {
+      allocateProjectSpend(
+        entry,
+        project.designStart || project.designStartDate,
+        project.designDuration,
+        designBudget
+      );
+    }
+
+    if (constructionBudget > 0) {
+      allocateProjectSpend(
+        entry,
+        project.constructionStart || project.constructionStartDate,
+        project.constructionDuration,
+        constructionBudget
+      );
+    }
+
+    breakdown.push(entry);
+  });
+
+  return breakdown.sort((a, b) => {
+    const aTime = a.designStart ? a.designStart.getTime() : Number.POSITIVE_INFINITY;
+    const bTime = b.designStart ? b.designStart.getTime() : Number.POSITIVE_INFINITY;
+    if (aTime === bTime) {
+      return (a.name || "").localeCompare(b.name || "");
+    }
+    return aTime - bTime;
+  });
+};
+
+const buildFundingAssumptionMap = (assumptions = []) => {
+  const map = new Map();
+  (assumptions || []).forEach((assumption) => {
+    if (!assumption) {
+      return;
+    }
+    const key = assumption.fundingSourceId == null
+      ? "unassigned"
+      : String(assumption.fundingSourceId);
+    map.set(key, assumption);
+  });
+  return map;
+};
+
+const calculateLevelDebtPayment = (principal, interestRatePercent, termYears) => {
+  const principalAmount = sanitizeNumber(principal, 0);
+  const term = Math.max(1, sanitizePositiveInteger(termYears, 1));
+  const ratePercent = sanitizeNumber(interestRatePercent, 0);
+  const rate = ratePercent / 100;
+
+  if (rate <= 0) {
+    return principalAmount / term;
+  }
+
+  const factor = rate * (1 + rate) ** term;
+  return (principalAmount * factor) / ((1 + rate) ** term - 1);
+};
+
+export const sanitizeExistingDebtManualTotals = (manualTotals = {}) => {
+  const sanitized = {};
+
+  if (!manualTotals || typeof manualTotals !== "object") {
+    return sanitized;
+  }
+
+  Object.entries(manualTotals).forEach(([yearKey, rawValue]) => {
+    const year = Number(yearKey);
+    const amount = sanitizeNumber(rawValue, 0);
+    if (Number.isFinite(year) && Number.isFinite(amount)) {
+      sanitized[year] = amount;
+    }
+  });
+
+  return sanitized;
+};
+
+export const sanitizeExistingDebtInstrument = (instrument = {}) => {
+  if (!instrument || typeof instrument !== "object") {
+    return null;
+  }
+
+  const fallbackId =
+    typeof globalThis !== "undefined" &&
+    globalThis.crypto &&
+    typeof globalThis.crypto.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `existing-debt-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  const id = instrument.id || fallbackId;
+  const label =
+    typeof instrument.label === "string" && instrument.label.trim()
+      ? instrument.label.trim()
+      : "Existing Debt";
+
+  const financingType =
+    instrument.financingType === "bond" || instrument.financingType === "srf"
+      ? instrument.financingType
+      : "bond";
+
+  const outstandingPrincipal = Math.max(0, sanitizeNumber(instrument.outstandingPrincipal, 0));
+  const interestRate = Math.max(0, sanitizeNumber(instrument.interestRate, 0));
+  const termYears = Math.max(1, sanitizePositiveInteger(instrument.termYears, 1));
+  const firstPaymentYear = sanitizePositiveInteger(instrument.firstPaymentYear, new Date().getFullYear());
+  const interestOnlyYears = Math.max(0, sanitizePositiveInteger(instrument.interestOnlyYears, 0));
+
+  return {
+    id,
+    label,
+    financingType,
+    outstandingPrincipal,
+    interestRate,
+    termYears,
+    firstPaymentYear,
+    interestOnlyYears,
+  };
+};
+
+export const sanitizeExistingDebtInstrumentList = (instruments = []) => {
+  if (!Array.isArray(instruments)) {
+    return [];
+  }
+
+  return instruments
+    .map((instrument) => sanitizeExistingDebtInstrument(instrument))
+    .filter(Boolean);
+};
+
+const buildExistingDebtInstrumentSchedule = (
+  instrument,
+  startYear,
+  projectionYears
+) => {
+  const horizonStart = sanitizePositiveInteger(
+    startYear,
+    new Date().getFullYear()
+  );
+  const totalYears = Math.max(1, sanitizePositiveInteger(projectionYears, 1));
+  const horizonEnd = horizonStart + totalYears - 1;
+
+  const sanitizedInstrument = sanitizeExistingDebtInstrument(instrument);
+  if (!sanitizedInstrument) {
+    return null;
+  }
+
+  const {
+    id,
+    label,
+    financingType,
+    outstandingPrincipal,
+    interestRate,
+    termYears,
+    firstPaymentYear,
+    interestOnlyYears,
+  } = sanitizedInstrument;
+
+  if (!(outstandingPrincipal > 0)) {
+    return {
+      id,
+      label,
+      financingType,
+      outstandingPrincipal,
+      interestRate,
+      termYears,
+      firstPaymentYear,
+      interestOnlyYears,
+      totalsByYear: {},
+      interestByYear: {},
+      principalByYear: {},
+    };
+  }
+
+  const paymentStartYear = Number.isFinite(firstPaymentYear)
+    ? firstPaymentYear
+    : horizonStart;
+  const rate = interestRate / 100;
+  const totalsByYear = {};
+  const interestByYear = {};
+  const principalByYear = {};
+
+  let remainingPrincipal = outstandingPrincipal;
+  const interestOnlyWindow = Math.min(interestOnlyYears, termYears);
+  const amortizationYears = Math.max(0, termYears - interestOnlyWindow);
+
+  for (let offset = 0; offset < interestOnlyWindow; offset += 1) {
+    const year = paymentStartYear + offset;
+    const interestPayment = rate > 0 ? remainingPrincipal * rate : 0;
+    if (year >= horizonStart && year <= horizonEnd) {
+      totalsByYear[year] = (totalsByYear[year] || 0) + interestPayment;
+      interestByYear[year] = (interestByYear[year] || 0) + interestPayment;
+      principalByYear[year] = principalByYear[year] || 0;
+    }
+  }
+
+  if (amortizationYears <= 0) {
+    return {
+      id,
+      label,
+      financingType,
+      outstandingPrincipal,
+      interestRate,
+      termYears,
+      firstPaymentYear,
+      interestOnlyYears,
+      totalsByYear,
+      interestByYear,
+      principalByYear,
+    };
+  }
+
+  const amortizationStartYear = paymentStartYear + interestOnlyWindow;
+  const annualPayment = calculateLevelDebtPayment(
+    remainingPrincipal,
+    interestRate,
+    amortizationYears
+  );
+
+  for (let i = 0; i < amortizationYears; i += 1) {
+    const year = amortizationStartYear + i;
+    const interestPayment = rate > 0 ? remainingPrincipal * rate : 0;
+    let principalPayment = annualPayment - interestPayment;
+
+    if (principalPayment < 0) {
+      principalPayment = 0;
+    }
+
+    if (principalPayment > remainingPrincipal || i === amortizationYears - 1) {
+      principalPayment = remainingPrincipal;
+    }
+
+    const paymentAmount = interestPayment + principalPayment;
+    remainingPrincipal = Math.max(0, remainingPrincipal - principalPayment);
+
+    if (year >= horizonStart && year <= horizonEnd) {
+      totalsByYear[year] = (totalsByYear[year] || 0) + paymentAmount;
+      interestByYear[year] = (interestByYear[year] || 0) + interestPayment;
+      principalByYear[year] = (principalByYear[year] || 0) + principalPayment;
+    }
+  }
+
+  return {
+    id,
+    label,
+    financingType,
+    outstandingPrincipal,
+    interestRate,
+    termYears,
+    firstPaymentYear,
+    interestOnlyYears,
+    totalsByYear,
+    interestByYear,
+    principalByYear,
+  };
+};
+
+export const calculateExistingDebtSchedule = ({
+  manualTotals = {},
+  instruments = [],
+  startYear,
+  projectionYears,
+}) => {
+  const sanitizedManual = sanitizeExistingDebtManualTotals(manualTotals);
+  const sanitizedStartYear = sanitizePositiveInteger(
+    startYear,
+    new Date().getFullYear()
+  );
+  const totalYears = Math.max(1, sanitizePositiveInteger(projectionYears, 1));
+  const horizonEnd = sanitizedStartYear + totalYears - 1;
+
+  const manualByYear = {};
+  const totalsByYear = {};
+  const interestByYear = {};
+  const principalByYear = {};
+
+  Object.entries(sanitizedManual).forEach(([yearKey, amount]) => {
+    const year = Number(yearKey);
+    if (!Number.isFinite(year)) {
+      return;
+    }
+    if (year < sanitizedStartYear || year > horizonEnd) {
+      return;
+    }
+    manualByYear[year] = amount;
+    totalsByYear[year] = (totalsByYear[year] || 0) + amount;
+  });
+
+  const instrumentSummaries = [];
+
+  sanitizeExistingDebtInstrumentList(instruments).forEach((instrument) => {
+    const summary = buildExistingDebtInstrumentSchedule(
+      instrument,
+      sanitizedStartYear,
+      totalYears
+    );
+    if (!summary) {
+      return;
+    }
+
+    instrumentSummaries.push(summary);
+
+    Object.entries(summary.totalsByYear).forEach(([yearKey, amount]) => {
+      const year = Number(yearKey);
+      if (!Number.isFinite(year)) {
+        return;
+      }
+      totalsByYear[year] = (totalsByYear[year] || 0) + amount;
+    });
+
+    Object.entries(summary.interestByYear).forEach(([yearKey, amount]) => {
+      const year = Number(yearKey);
+      if (!Number.isFinite(year)) {
+        return;
+      }
+      interestByYear[year] = (interestByYear[year] || 0) + amount;
+    });
+
+    Object.entries(summary.principalByYear).forEach(([yearKey, amount]) => {
+      const year = Number(yearKey);
+      if (!Number.isFinite(year)) {
+        return;
+      }
+      principalByYear[year] = (principalByYear[year] || 0) + amount;
+    });
+  });
+
+  return {
+    manualByYear,
+    totalsByYear,
+    interestByYear,
+    principalByYear,
+    instrumentSummaries,
+    startYear: sanitizedStartYear,
+    projectionYears: totalYears,
+  };
+};
+
+export const buildDebtServiceSchedule = (
+  spendPlan,
+  fundingSourceAssumptions,
+  startYear,
+  projectionYears
+) => {
+  const totalPaymentsByYear = {};
+  const interestByYear = {};
+  const principalByYear = {};
+  const cashUses = {};
+  const debtIssuedBySource = {};
+  const financingSchedules = [];
+
+  const assumptionMap = buildFundingAssumptionMap(fundingSourceAssumptions);
+  const projectionEndYear = startYear + projectionYears;
+
+  const fundingDraws = new Map();
+
+  const years = Object.keys(spendPlan)
+    .map((year) => Number(year))
+    .filter((year) => Number.isFinite(year))
+    .sort((a, b) => a - b);
+
+  years.forEach((year) => {
+    const yearEntry = spendPlan[year];
+    if (!yearEntry) {
+      return;
+    }
+
+    Object.entries(yearEntry.byFundingSource || {}).forEach(([fundingKey, amount]) => {
+      const spendAmount = sanitizeNumber(amount, 0);
+      if (!(spendAmount > 0)) {
+        return;
+      }
+
+      const assumption = assumptionMap.get(fundingKey);
+      const financingType = assumption?.financingType || "cash";
+
+      if (financingType === "cash") {
+        cashUses[year] = (cashUses[year] || 0) + spendAmount;
+        return;
+      }
+
+      if (financingType === "grant") {
+        return;
+      }
+
+      const numericYear = Number(year);
+      if (!Number.isFinite(numericYear)) {
+        return;
+      }
+
+      if (!fundingDraws.has(fundingKey)) {
+        fundingDraws.set(fundingKey, {
+          assumption,
+          draws: new Map(),
+        });
+      }
+
+      const record = fundingDraws.get(fundingKey);
+      record.draws.set(numericYear, (record.draws.get(numericYear) || 0) + spendAmount);
+    });
+  });
+
+  const pushPayment = (year, payment, interest, principal) => {
+    if (Number.isFinite(payment)) {
+      addToYearMap(totalPaymentsByYear, year, payment);
+    }
+    if (Number.isFinite(interest)) {
+      addToYearMap(interestByYear, year, interest);
+    }
+    if (Number.isFinite(principal)) {
+      addToYearMap(principalByYear, year, principal);
+    }
+  };
+
+  const isWithinProjection = (year) =>
+    Number.isFinite(year) && year >= startYear && year < projectionEndYear;
+
+  fundingDraws.forEach((record, fundingKey) => {
+    const { assumption, draws } = record;
+    const financingType = assumption?.financingType || "cash";
+    const interestRatePercent = sanitizeNumber(assumption?.interestRate, 0);
+    const interestRate = interestRatePercent / 100;
+    const termYears = Math.max(1, sanitizePositiveInteger(assumption?.termYears, 1));
+    const sourceName =
+      assumption?.sourceName ||
+      (fundingKey === "unassigned" ? "Unassigned Funding Source" : `Funding Source ${fundingKey}`);
+
+    const drawEntries = Array.from(draws.entries())
+      .map(([year, amount]) => ({
+        year: Number(year),
+        amount: sanitizeNumber(amount, 0),
+      }))
+      .filter((entry) => Number.isFinite(entry.year) && entry.amount > 0)
+      .sort((a, b) => a.year - b.year);
+
+    if (drawEntries.length === 0) {
+      return;
+    }
+
+    const issuedWithinHorizon = drawEntries.reduce((sum, entry) => {
+      if (isWithinProjection(entry.year)) {
+        return sum + entry.amount;
+      }
+      return sum;
+    }, 0);
+
+    if (financingType === "srf") {
+      const loanDetails = {
+        fundingKey,
+        sourceName,
+        financingType,
+        interestRate: interestRatePercent,
+        termYears,
+        totalIssued: 0,
+        interestOnly: [],
+        amortization: [],
+        amortizationStartYear: null,
+        annualPayment: 0,
+      };
+
+      const drawMap = new Map();
+      drawEntries.forEach((entry) => {
+        drawMap.set(entry.year, (drawMap.get(entry.year) || 0) + entry.amount);
+      });
+
+      const drawYears = Array.from(drawMap.keys()).sort((a, b) => a - b);
+      if (drawYears.length === 0) {
+        return;
+      }
+
+      const firstDrawYear = drawYears[0];
+      const lastDrawYear = drawYears[drawYears.length - 1];
+      let outstanding = 0;
+
+      for (let year = firstDrawYear; year <= lastDrawYear; year += 1) {
+        const drawAmount = sanitizeNumber(drawMap.get(year) || 0, 0);
+        const openingBalance = outstanding;
+        outstanding += drawAmount;
+        const averageOutstanding = openingBalance + drawAmount / 2;
+        const interestPayment = interestRate > 0 ? averageOutstanding * interestRate : 0;
+
+        if (isWithinProjection(year)) {
+          pushPayment(year, interestPayment, interestPayment, 0);
+          loanDetails.interestOnly.push({
+            year,
+            drawAmount,
+            interestPayment,
+            outstandingBalance: outstanding,
+          });
+        }
+      }
+
+      const totalPrincipal = outstanding;
+      if (totalPrincipal > 0) {
+        loanDetails.totalIssued = totalPrincipal;
+        const annualPayment = calculateLevelDebtPayment(totalPrincipal, interestRatePercent, termYears);
+        loanDetails.annualPayment = annualPayment;
+        loanDetails.amortizationStartYear = lastDrawYear + 1;
+
+        let remainingPrincipal = totalPrincipal;
+
+        for (let i = 0; i < termYears; i += 1) {
+          const paymentYear = lastDrawYear + 1 + i;
+          const interestPayment = interestRate > 0 ? remainingPrincipal * interestRate : 0;
+          let principalPayment = annualPayment - interestPayment;
+          if (principalPayment < 0) {
+            principalPayment = 0;
+          }
+          if (principalPayment > remainingPrincipal || i === termYears - 1) {
+            principalPayment = remainingPrincipal;
+          }
+          const paymentAmount = interestPayment + principalPayment;
+          remainingPrincipal = Math.max(0, remainingPrincipal - principalPayment);
+
+          if (isWithinProjection(paymentYear)) {
+            pushPayment(paymentYear, paymentAmount, interestPayment, principalPayment);
+            loanDetails.amortization.push({
+              year: paymentYear,
+              payment: paymentAmount,
+              interestPayment,
+              principalPayment,
+              remainingBalance: remainingPrincipal,
+            });
+          }
+        }
+
+        if (issuedWithinHorizon > 0) {
+          debtIssuedBySource[fundingKey] =
+            (debtIssuedBySource[fundingKey] || 0) + issuedWithinHorizon;
+        }
+      }
+
+      financingSchedules.push(loanDetails);
+      return;
+    }
+
+    const bondDetails = {
+      fundingKey,
+      sourceName,
+      financingType,
+      interestRate: interestRatePercent,
+      termYears,
+      totalIssued: 0,
+      issues: [],
+    };
+
+    drawEntries.forEach((entry) => {
+      const issueAmount = entry.amount;
+      if (!(issueAmount > 0)) {
+        return;
+      }
+
+      const annualPayment = calculateLevelDebtPayment(issueAmount, interestRatePercent, termYears);
+      const paymentStartYear = entry.year + 1;
+      const issueDetail = {
+        year: entry.year,
+        amount: issueAmount,
+        paymentStartYear,
+        annualPayment,
+        firstYearInterest: 0,
+        firstYearPrincipal: 0,
+        paymentsWithinHorizon: [],
+      };
+
+      let remainingPrincipal = issueAmount;
+
+      for (let i = 0; i < termYears; i += 1) {
+        const paymentYear = paymentStartYear + i;
+        const interestPayment = interestRate > 0 ? remainingPrincipal * interestRate : 0;
+        let principalPayment = annualPayment - interestPayment;
+        if (principalPayment < 0) {
+          principalPayment = 0;
+        }
+        if (principalPayment > remainingPrincipal || i === termYears - 1) {
+          principalPayment = remainingPrincipal;
+        }
+        const paymentAmount = interestPayment + principalPayment;
+        remainingPrincipal = Math.max(0, remainingPrincipal - principalPayment);
+
+        if (i === 0) {
+          issueDetail.firstYearInterest = interestPayment;
+          issueDetail.firstYearPrincipal = principalPayment;
+        }
+
+        if (isWithinProjection(paymentYear)) {
+          pushPayment(paymentYear, paymentAmount, interestPayment, principalPayment);
+          issueDetail.paymentsWithinHorizon.push({
+            year: paymentYear,
+            payment: paymentAmount,
+            interestPayment,
+            principalPayment,
+            remainingBalance: remainingPrincipal,
+          });
+        }
+      }
+
+      bondDetails.issues.push(issueDetail);
+      bondDetails.totalIssued += issueAmount;
+      if (isWithinProjection(entry.year)) {
+        debtIssuedBySource[fundingKey] =
+          (debtIssuedBySource[fundingKey] || 0) + issueAmount;
+      }
+    });
+
+    if (bondDetails.totalIssued > 0) {
+      financingSchedules.push(bondDetails);
+    }
+  });
+
+  return {
+    debtServiceByYear: totalPaymentsByYear,
+    debtServiceInterestByYear: interestByYear,
+    debtServicePrincipalByYear: principalByYear,
+    cashUsesByYear: cashUses,
+    debtIssuedBySource,
+    financingSchedules,
+  };
+};
+
+const safeDivide = (numerator, denominator) => {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) {
+    return null;
+  }
+  return numerator / denominator;
+};
+
+export const calculateFinancialForecast = ({
+  projectTimelines = [],
+  operatingBudget = [],
+  financialConfig = {},
+  fundingSourceAssumptions = [],
+}) => {
+  const startYear = sanitizePositiveInteger(
+    financialConfig?.startYear,
+    new Date().getFullYear()
+  );
+  const projectionYears = Math.max(1, sanitizePositiveInteger(financialConfig?.projectionYears, 10));
+  const startingCash = sanitizeNumber(financialConfig?.startingCashBalance, 0);
+  const targetCoverageRatio = sanitizeNumber(financialConfig?.targetCoverageRatio, 1.25);
+
+  const normalizedBudget = ensureBudgetYears(operatingBudget, startYear, projectionYears);
+  const budgetMap = new Map(normalizedBudget.map((row) => [row.year, row]));
+
+  const spendPlan = buildProjectSpendPlan(projectTimelines);
+  const {
+    debtServiceByYear,
+    debtServiceInterestByYear,
+    debtServicePrincipalByYear,
+    cashUsesByYear,
+    debtIssuedBySource,
+    financingSchedules,
+  } = buildDebtServiceSchedule(
+    spendPlan,
+    fundingSourceAssumptions,
+    startYear,
+    projectionYears
+  );
+
+  const years = [];
+  for (let i = 0; i < projectionYears; i += 1) {
+    years.push(startYear + i);
+  }
+
+  const forecast = [];
+  let runningCash = startingCash;
+  let minCoverage = Number.POSITIVE_INFINITY;
+  let minDaysCashOnHand = Number.POSITIVE_INFINITY;
+  let maxAdditionalRateIncrease = 0;
+
+  years.forEach((year) => {
+    const budgetRow = budgetMap.get(year) || cloneBudgetRow(year, null);
+    const baseOperatingRevenue = sanitizeNumber(budgetRow.operatingRevenue, 0);
+    const plannedRateIncreasePercent = sanitizePercent(budgetRow.rateIncreasePercent, 0);
+    const adjustedOperatingRevenue =
+      baseOperatingRevenue * (1 + plannedRateIncreasePercent / 100);
+    const nonOperatingRevenue = sanitizeNumber(budgetRow.nonOperatingRevenue, 0);
+    const omExpenses = sanitizeNumber(budgetRow.omExpenses, 0);
+    const salaries = sanitizeNumber(budgetRow.salaries, 0);
+    const adminExpenses = sanitizeNumber(budgetRow.adminExpenses, 0);
+    const existingDebtService = sanitizeNumber(budgetRow.existingDebtService, 0);
+
+    const totalOperatingExpenses = omExpenses + salaries + adminExpenses;
+    const netRevenueBeforeDebt =
+      adjustedOperatingRevenue + nonOperatingRevenue - totalOperatingExpenses;
+
+    const newDebtService = sanitizeNumber(debtServiceByYear[year], 0);
+    const totalDebtService = existingDebtService + newDebtService;
+    const coverageRatio =
+      totalDebtService > 0 ? netRevenueBeforeDebt / totalDebtService : null;
+
+    if (coverageRatio !== null && coverageRatio < minCoverage) {
+      minCoverage = coverageRatio;
+    }
+
+    const requiredNetRevenue =
+      totalDebtService > 0 ? targetCoverageRatio * totalDebtService : 0;
+    const revenueShortfall = requiredNetRevenue - netRevenueBeforeDebt;
+    let additionalRateIncreaseNeeded = 0;
+    if (revenueShortfall > 0 && baseOperatingRevenue > 0) {
+      additionalRateIncreaseNeeded =
+        (revenueShortfall / baseOperatingRevenue) * 100;
+    }
+
+    if (additionalRateIncreaseNeeded > maxAdditionalRateIncrease) {
+      maxAdditionalRateIncrease = additionalRateIncreaseNeeded;
+    }
+
+    const operatingCashFlow = netRevenueBeforeDebt - totalDebtService;
+    const cashCapex = sanitizeNumber(cashUsesByYear[year], 0);
+    runningCash += operatingCashFlow - cashCapex;
+
+    const daysCashOnHand =
+      totalOperatingExpenses > 0
+        ? (runningCash / totalOperatingExpenses) * 365
+        : null;
+
+    if (daysCashOnHand !== null && daysCashOnHand < minDaysCashOnHand) {
+      minDaysCashOnHand = daysCashOnHand;
+    }
+
+    forecast.push({
+      year,
+      baseOperatingRevenue,
+      adjustedOperatingRevenue,
+      plannedRateIncreasePercent,
+      nonOperatingRevenue,
+      omExpenses,
+      salaries,
+      adminExpenses,
+      totalOperatingExpenses,
+      netRevenueBeforeDebt,
+      existingDebtService,
+      newDebtService,
+      totalDebtService,
+      coverageRatio,
+      additionalRateIncreaseNeeded,
+      cashFundedCapex: cashCapex,
+      cipSpend: sanitizeNumber(spendPlan[year]?.totalSpend, 0),
+      endingCashBalance: runningCash,
+      daysCashOnHand,
+    });
+  });
+
+  if (!Number.isFinite(minCoverage)) {
+    minCoverage = null;
+  }
+
+  if (!Number.isFinite(minDaysCashOnHand)) {
+    minDaysCashOnHand = null;
+  }
+
+  const totalCapitalSpend = years.reduce(
+    (sum, year) => sum + sanitizeNumber(spendPlan?.[year]?.totalSpend, 0),
+    0
+  );
+  const totalCashCapex = years.reduce(
+    (sum, year) => sum + sanitizeNumber(cashUsesByYear?.[year], 0),
+    0
+  );
+  const totalDebtIssued = Object.values(debtIssuedBySource).reduce(
+    (sum, value) => sum + sanitizeNumber(value, 0),
+    0
+  );
+
+  return {
+    forecast,
+    spendPlan,
+    debtServiceByYear,
+    debtServiceInterestByYear,
+    debtServicePrincipalByYear,
+    cashUsesByYear,
+    debtIssuedBySource,
+    financingSchedules,
+    totals: {
+      totalCapitalSpend,
+      totalCashCapex,
+      totalDebtIssued,
+      minCoverageRatio: minCoverage,
+      endingCashBalance: forecast[forecast.length - 1]?.endingCashBalance ?? startingCash,
+      maxAdditionalRateIncrease,
+      minDaysCashOnHand,
+    },
+  };
+};
+
+export const FINANCING_TYPE_OPTIONS = [
+  { value: "cash", label: "Pay-Go Cash" },
+  { value: "bond", label: "Revenue Bond" },
+  { value: "srf", label: "SRF Loan" },
+  { value: "grant", label: "Grant / External" },
+];
+
+export const formatCurrency = (value, options = {}) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return options.fallback ?? "-";
+  }
+
+  const compact = Boolean(options.compact);
+  const formatOptions = {
+    style: "currency",
+    currency: options.currency || "USD",
+    minimumFractionDigits:
+      options.minimumFractionDigits ?? (compact ? 0 : 0),
+    maximumFractionDigits:
+      options.maximumFractionDigits ?? (compact ? 1 : 0),
+  };
+
+  if (compact) {
+    formatOptions.notation = "compact";
+    formatOptions.compactDisplay = options.compactDisplay || "short";
+  }
+
+  return new Intl.NumberFormat("en-US", formatOptions).format(numeric);
+};
+
+export const formatPercent = (value, options = {}) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return "-";
+  }
+  return `${numeric.toFixed(options.decimals ?? 1)}%`;
+};
+
+export const formatCoverageRatio = (value, decimals = 2) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return "—";
+  }
+  return `${numeric.toFixed(decimals)}x`;
+};
+

--- a/supabase/migrations/20241028000000_financial_modeling_tables.sql
+++ b/supabase/migrations/20241028000000_financial_modeling_tables.sql
@@ -1,0 +1,160 @@
+-- Create persistence tables for the financial modeling module
+create table if not exists public.utility_financial_profiles (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  utility_key text not null,
+  financial_config jsonb not null default '{}'::jsonb,
+  budget_escalations jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint utility_financial_profiles_utility_key_check
+    check (utility_key in ('water', 'sewer', 'power', 'gas', 'stormwater')),
+  unique (organization_id, utility_key)
+);
+
+create index if not exists utility_financial_profiles_org_idx
+  on public.utility_financial_profiles (organization_id);
+
+alter table public.utility_financial_profiles enable row level security;
+
+drop trigger if exists utility_financial_profiles_set_updated_at on public.utility_financial_profiles;
+create trigger utility_financial_profiles_set_updated_at
+before update on public.utility_financial_profiles
+for each row execute function public.set_updated_at();
+
+create table if not exists public.utility_operating_budgets (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  utility_key text not null,
+  fiscal_year integer not null,
+  operating_revenue numeric default 0,
+  non_operating_revenue numeric default 0,
+  om_expenses numeric default 0,
+  salaries numeric default 0,
+  admin_expenses numeric default 0,
+  existing_debt_service numeric default 0,
+  rate_increase_percent numeric default 0,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint utility_operating_budgets_utility_key_check
+    check (utility_key in ('water', 'sewer', 'power', 'gas', 'stormwater')),
+  constraint utility_operating_budgets_fiscal_year_check
+    check (fiscal_year >= 1900),
+  unique (organization_id, utility_key, fiscal_year)
+);
+
+create index if not exists utility_operating_budgets_org_idx
+  on public.utility_operating_budgets (organization_id, utility_key);
+
+alter table public.utility_operating_budgets enable row level security;
+
+drop trigger if exists utility_operating_budgets_set_updated_at on public.utility_operating_budgets;
+create trigger utility_operating_budgets_set_updated_at
+before update on public.utility_operating_budgets
+for each row execute function public.set_updated_at();
+
+create table if not exists public.project_type_utilities (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  project_type_id uuid not null references public.project_types (id) on delete cascade,
+  utility_key text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint project_type_utilities_utility_key_check
+    check (
+      utility_key is null
+      or utility_key in ('water', 'sewer', 'power', 'gas', 'stormwater')
+    ),
+  unique (organization_id, project_type_id)
+);
+
+create index if not exists project_type_utilities_org_idx
+  on public.project_type_utilities (organization_id, project_type_id);
+
+alter table public.project_type_utilities enable row level security;
+
+drop trigger if exists project_type_utilities_set_updated_at on public.project_type_utilities;
+create trigger project_type_utilities_set_updated_at
+before update on public.project_type_utilities
+for each row execute function public.set_updated_at();
+
+create table if not exists public.funding_source_financing_assumptions (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  funding_source_id uuid not null references public.funding_sources (id) on delete cascade,
+  source_name text,
+  financing_type text not null default 'cash',
+  interest_rate numeric default 0,
+  term_years integer default 0,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint funding_source_financing_assumptions_financing_type_check
+    check (financing_type in ('cash', 'bond', 'srf', 'grant')),
+  unique (organization_id, funding_source_id)
+);
+
+create index if not exists funding_source_financing_assumptions_org_idx
+  on public.funding_source_financing_assumptions (organization_id, funding_source_id);
+
+alter table public.funding_source_financing_assumptions enable row level security;
+
+drop trigger if exists funding_source_financing_assumptions_set_updated_at on public.funding_source_financing_assumptions;
+create trigger funding_source_financing_assumptions_set_updated_at
+before update on public.funding_source_financing_assumptions
+for each row execute function public.set_updated_at();
+
+-- Row level security policies
+
+drop policy if exists "Members can view utility financial profiles" on public.utility_financial_profiles;
+create policy "Members can view utility financial profiles" on public.utility_financial_profiles
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage utility financial profiles" on public.utility_financial_profiles;
+create policy "Editors manage utility financial profiles" on public.utility_financial_profiles
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view utility operating budgets" on public.utility_operating_budgets;
+create policy "Members can view utility operating budgets" on public.utility_operating_budgets
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage utility operating budgets" on public.utility_operating_budgets;
+create policy "Editors manage utility operating budgets" on public.utility_operating_budgets
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view project type utilities" on public.project_type_utilities;
+create policy "Members can view project type utilities" on public.project_type_utilities
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage project type utilities" on public.project_type_utilities;
+create policy "Editors manage project type utilities" on public.project_type_utilities
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view funding source assumptions" on public.funding_source_financing_assumptions;
+create policy "Members can view funding source assumptions" on public.funding_source_financing_assumptions
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage funding source assumptions" on public.funding_source_financing_assumptions;
+create policy "Editors manage funding source assumptions" on public.funding_source_financing_assumptions
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+-- Ensure authenticated users retain access to the new tables
+
+grant select, insert, update, delete on public.utility_financial_profiles to authenticated;
+
+grant select, insert, update, delete on public.utility_operating_budgets to authenticated;
+
+grant select, insert, update, delete on public.project_type_utilities to authenticated;
+
+grant select, insert, update, delete on public.funding_source_financing_assumptions to authenticated;

--- a/supabase/migrations/20241030000000_existing_debt_columns.sql
+++ b/supabase/migrations/20241030000000_existing_debt_columns.sql
@@ -1,0 +1,4 @@
+-- Add JSON columns to store existing debt schedules and instrument definitions
+ALTER TABLE utility_financial_profiles
+ADD COLUMN IF NOT EXISTS existing_debt_manual_totals JSONB NOT NULL DEFAULT '{}'::jsonb,
+ADD COLUMN IF NOT EXISTS existing_debt_instruments JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -214,6 +214,79 @@ create index if not exists staff_assignments_organization_id_idx on public.staff
 create index if not exists staff_assignments_project_id_idx on public.staff_assignments (project_id);
 create index if not exists staff_assignments_staff_id_idx on public.staff_assignments (staff_id);
 
+create table if not exists public.utility_financial_profiles (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  utility_key text not null,
+  financial_config jsonb not null default '{}'::jsonb,
+  budget_escalations jsonb not null default '{}'::jsonb,
+  existing_debt_manual_totals jsonb not null default '{}'::jsonb,
+  existing_debt_instruments jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint utility_financial_profiles_utility_key_check
+    check (utility_key in ('water', 'sewer', 'power', 'gas', 'stormwater')),
+  unique (organization_id, utility_key)
+);
+create index if not exists utility_financial_profiles_org_idx on public.utility_financial_profiles (organization_id);
+
+create table if not exists public.utility_operating_budgets (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  utility_key text not null,
+  fiscal_year integer not null,
+  operating_revenue numeric default 0,
+  non_operating_revenue numeric default 0,
+  om_expenses numeric default 0,
+  salaries numeric default 0,
+  admin_expenses numeric default 0,
+  existing_debt_service numeric default 0,
+  rate_increase_percent numeric default 0,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint utility_operating_budgets_utility_key_check
+    check (utility_key in ('water', 'sewer', 'power', 'gas', 'stormwater')),
+  constraint utility_operating_budgets_fiscal_year_check
+    check (fiscal_year >= 1900),
+  unique (organization_id, utility_key, fiscal_year)
+);
+create index if not exists utility_operating_budgets_org_idx
+  on public.utility_operating_budgets (organization_id, utility_key);
+
+create table if not exists public.project_type_utilities (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  project_type_id uuid not null references public.project_types (id) on delete cascade,
+  utility_key text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint project_type_utilities_utility_key_check
+    check (
+      utility_key is null
+      or utility_key in ('water', 'sewer', 'power', 'gas', 'stormwater')
+    ),
+  unique (organization_id, project_type_id)
+);
+create index if not exists project_type_utilities_org_idx
+  on public.project_type_utilities (organization_id, project_type_id);
+
+create table if not exists public.funding_source_financing_assumptions (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations (id) on delete cascade,
+  funding_source_id uuid not null references public.funding_sources (id) on delete cascade,
+  source_name text,
+  financing_type text not null default 'cash',
+  interest_rate numeric default 0,
+  term_years integer default 0,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint funding_source_financing_assumptions_financing_type_check
+    check (financing_type in ('cash', 'bond', 'srf', 'grant')),
+  unique (organization_id, funding_source_id)
+);
+create index if not exists funding_source_financing_assumptions_org_idx
+  on public.funding_source_financing_assumptions (organization_id, funding_source_id);
+
 create or replace function public.set_updated_at()
 returns trigger as $$
 begin
@@ -302,6 +375,26 @@ for each row execute function public.set_updated_at();
 drop trigger if exists staff_assignments_set_updated_at on public.staff_assignments;
 create trigger staff_assignments_set_updated_at
 before update on public.staff_assignments
+for each row execute function public.set_updated_at();
+
+drop trigger if exists utility_financial_profiles_set_updated_at on public.utility_financial_profiles;
+create trigger utility_financial_profiles_set_updated_at
+before update on public.utility_financial_profiles
+for each row execute function public.set_updated_at();
+
+drop trigger if exists utility_operating_budgets_set_updated_at on public.utility_operating_budgets;
+create trigger utility_operating_budgets_set_updated_at
+before update on public.utility_operating_budgets
+for each row execute function public.set_updated_at();
+
+drop trigger if exists project_type_utilities_set_updated_at on public.project_type_utilities;
+create trigger project_type_utilities_set_updated_at
+before update on public.project_type_utilities
+for each row execute function public.set_updated_at();
+
+drop trigger if exists funding_source_financing_assumptions_set_updated_at on public.funding_source_financing_assumptions;
+create trigger funding_source_financing_assumptions_set_updated_at
+before update on public.funding_source_financing_assumptions
 for each row execute function public.set_updated_at();
 
 create or replace function public.is_superuser()
@@ -639,6 +732,10 @@ alter table public.staff_members enable row level security;
 alter table public.projects enable row level security;
 alter table public.staff_allocations enable row level security;
 alter table public.staff_assignments enable row level security;
+alter table public.utility_financial_profiles enable row level security;
+alter table public.utility_operating_budgets enable row level security;
+alter table public.project_type_utilities enable row level security;
+alter table public.funding_source_financing_assumptions enable row level security;
 
 drop policy if exists "Members can view organizations" on public.organizations;
 create policy "Organization directory visibility" on public.organizations
@@ -800,6 +897,50 @@ using (public.is_organization_member(organization_id));
 
 drop policy if exists "Editors manage staff assignments" on public.staff_assignments;
 create policy "Editors manage staff assignments" on public.staff_assignments
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view utility financial profiles" on public.utility_financial_profiles;
+create policy "Members can view utility financial profiles" on public.utility_financial_profiles
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage utility financial profiles" on public.utility_financial_profiles;
+create policy "Editors manage utility financial profiles" on public.utility_financial_profiles
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view utility operating budgets" on public.utility_operating_budgets;
+create policy "Members can view utility operating budgets" on public.utility_operating_budgets
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage utility operating budgets" on public.utility_operating_budgets;
+create policy "Editors manage utility operating budgets" on public.utility_operating_budgets
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view project type utilities" on public.project_type_utilities;
+create policy "Members can view project type utilities" on public.project_type_utilities
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage project type utilities" on public.project_type_utilities;
+create policy "Editors manage project type utilities" on public.project_type_utilities
+for all
+using (public.can_edit_organization(organization_id))
+with check (public.can_edit_organization(organization_id));
+
+drop policy if exists "Members can view funding source assumptions" on public.funding_source_financing_assumptions;
+create policy "Members can view funding source assumptions" on public.funding_source_financing_assumptions
+for select
+using (public.is_organization_member(organization_id));
+
+drop policy if exists "Editors manage funding source assumptions" on public.funding_source_financing_assumptions;
+create policy "Editors manage funding source assumptions" on public.funding_source_financing_assumptions
 for all
 using (public.can_edit_organization(organization_id))
 with check (public.can_edit_organization(organization_id));


### PR DESCRIPTION
## Summary
- widen operating budget base-year and manual out-year inputs to comfortably capture million-to-billion scale figures
- enlarge the escalation column, adjust the header to Escalation (%/yr), and add a wider suffix label so units stay on one line

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68d1d7c277bc83299f2bbdc4b7511bab