### PR TITLE
Fix project effort template serialization

### DIFF
--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -3,6 +3,10 @@ import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../context/AuthContext';
 import { normalizeProjectBudgetBreakdown } from '../utils/projectBudgets';
 import {
+  normalizeEffortTemplate,
+  sanitizeTemplateHours,
+} from '../utils/projectEffortTemplates';
+import {
   sanitizeExistingDebtInstrumentList,
   sanitizeExistingDebtManualTotals,
 } from '../utils/financialModeling';
@@ -174,6 +178,35 @@ const staffAssignmentToRow = (assignment, organizationId) => ({
   design_hours: normalizeNullable(assignment.designHours) ?? 0,
   construction_hours: normalizeNullable(assignment.constructionHours) ?? 0,
 });
+
+const projectEffortTemplateFromRow = (row) => {
+  const camel = camelizeRecord(row);
+
+  return {
+    ...camel,
+    hoursByCategory: sanitizeTemplateHours(
+      parseJsonField(camel.hoursByCategory, {})
+    ),
+  };
+};
+
+const projectEffortTemplateToRow = (template, organizationId) => {
+  const normalized = normalizeEffortTemplate(template || {});
+  const hoursByCategory = sanitizeTemplateHours(
+    normalized.hoursByCategory || {}
+  );
+
+  return {
+    organization_id: organizationId,
+    name: normalized.name || '',
+    project_type_id: normalizeNullable(normalized.projectTypeId),
+    size_category: normalized.sizeCategory || null,
+    delivery_type: normalized.deliveryType || null,
+    notes: normalized.notes || null,
+    hours_by_category:
+      Object.keys(hoursByCategory).length > 0 ? hoursByCategory : null,
+  };
+};
 
 const UTILITY_KEYS = new Set(['water', 'sewer', 'power', 'gas', 'stormwater']);
 


### PR DESCRIPTION
## Summary
- import the project effort template utilities into the database hook
- add serializers that sanitize template hours when reading from or writing to Supabase
- ensure project effort template records return parsed hours so UI normalization works

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68d3670bd0048329b203a0011f2d3826