### PR TITLE
Model SRF loans as annual drawdowns

### DIFF
--- a/src/components/financial-modeling/views/DebtServiceView.js
+++ b/src/components/financial-modeling/views/DebtServiceView.js
@@ -770,11 +770,17 @@ const DebtServiceView = ({
                   )}
 
                   <div className="mt-4 rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600">
-                    {loan.amortizationStartYear
-                      ? `Amortization begins FY ${loan.amortizationStartYear} with level payment ${formatCurrency(
-                          loan.annualPayment || 0
-                        )} for ${loan.termYears} years.`
-                      : "No amortization is scheduled."}
+                    {loan.loans?.length
+                      ? `Each annual SRF loan accrues interest-only payments for ${loan.interestOnlyYears ?? 0} years before amortizing over ${loan.termYears} years${
+                          loan.amortizationStartYear
+                            ? `, beginning in FY ${loan.amortizationStartYear}.`
+                            : "."
+                        }`
+                      : loan.amortizationStartYear
+                        ? `Amortization begins FY ${loan.amortizationStartYear} with level payment ${formatCurrency(
+                            loan.annualPayment || 0
+                          )} for ${loan.termYears} years.`
+                        : "No amortization is scheduled."}
                   </div>
 
                   {loan.amortization?.length ? (


### PR DESCRIPTION
## Summary
- update SRF loan calculations to issue separate annual loans with five-year interest-only periods before amortization
- aggregate interest-only and amortization schedules across annual SRF loans and enhance UI messaging

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68d37801c89083298fd44d6af8378d8b