### PR TITLE
Improve fiscal year sanitization for operating budgets

### DIFF
--- a/src/hooks/__tests__/useDatabase.test.js
+++ b/src/hooks/__tests__/useDatabase.test.js
@@ -1,0 +1,90 @@
+import { __TEST_ONLY } from '../useDatabase';
+
+const { sanitizeFinancialConfig, sanitizeFiscalYear, operatingBudgetToRow } =
+  __TEST_ONLY;
+
+describe('sanitizeFiscalYear', () => {
+  it('returns fallback when value is null or undefined', () => {
+    expect(sanitizeFiscalYear(null, 2030)).toBe(2030);
+    expect(sanitizeFiscalYear(undefined, 2040)).toBe(2040);
+  });
+
+  it('normalizes numeric and string inputs within the valid range', () => {
+    expect(sanitizeFiscalYear(2024)).toBe(2024);
+    expect(sanitizeFiscalYear('2026')).toBe(2026);
+    expect(sanitizeFiscalYear('2050.4')).toBe(2050);
+  });
+
+  it('extracts four digit years embedded in formatted strings', () => {
+    expect(sanitizeFiscalYear('FY2028')).toBe(2028);
+    expect(sanitizeFiscalYear('Budget FY 2031/32')).toBe(2031);
+  });
+
+  it('rejects out-of-range values', () => {
+    expect(sanitizeFiscalYear(1899, 2025)).toBe(2025);
+    expect(sanitizeFiscalYear('1200', 2025)).toBe(2025);
+    expect(sanitizeFiscalYear('abc', 2025)).toBe(2025);
+  });
+});
+
+describe('sanitizeFinancialConfig', () => {
+  it('falls back to the current year when start year is missing or invalid', () => {
+    const currentYear = new Date().getFullYear();
+    expect(sanitizeFinancialConfig({}).startYear).toBe(currentYear);
+    expect(sanitizeFinancialConfig({ startYear: null }).startYear).toBe(currentYear);
+    expect(sanitizeFinancialConfig({ startYear: 1890 }).startYear).toBe(currentYear);
+  });
+
+  it('preserves valid configuration values', () => {
+    const config = sanitizeFinancialConfig({
+      startYear: 2028,
+      projectionYears: 7,
+      startingCashBalance: '500000',
+      targetCoverageRatio: 1.75,
+    });
+
+    expect(config.startYear).toBe(2028);
+    expect(config.projectionYears).toBe(7);
+    expect(config.startingCashBalance).toBe(500000);
+    expect(config.targetCoverageRatio).toBe(1.75);
+  });
+});
+
+describe('operatingBudgetToRow', () => {
+  const sampleRow = {
+    year: 2027,
+    revenueLineItems: [
+      { id: 'utilitySales', amount: 1250000 },
+      { id: 'nonOperatingRevenue', amount: 45000 },
+    ],
+    expenseLineItems: [
+      { id: 'operationsMaintenance', amount: 510000 },
+      { id: 'otherAdministrative', amount: 225000 },
+    ],
+    rateIncreasePercent: 3.25,
+    existingDebtService: 150000,
+  };
+
+  it('returns a normalized persistence payload when inputs are valid', () => {
+    const payload = operatingBudgetToRow('org-1', 'water', sampleRow);
+
+    expect(payload).not.toBeNull();
+    expect(payload.organization_id).toBe('org-1');
+    expect(payload.utility_key).toBe('water');
+    expect(payload.fiscal_year).toBe(2027);
+    expect(payload.operating_revenue).toBe(1250000);
+    expect(payload.non_operating_revenue).toBe(45000);
+    expect(payload.om_expenses).toBe(510000);
+    expect(payload.admin_expenses).toBe(225000);
+
+    const revenueItems = JSON.parse(payload.revenue_line_items);
+    const expenseItems = JSON.parse(payload.expense_line_items);
+    expect(Array.isArray(revenueItems)).toBe(true);
+    expect(Array.isArray(expenseItems)).toBe(true);
+  });
+
+  it('returns null when utility key or fiscal year is invalid', () => {
+    expect(operatingBudgetToRow('org-1', 'invalid', sampleRow)).toBeNull();
+    expect(operatingBudgetToRow('org-1', 'water', { ...sampleRow, year: 1899 })).toBeNull();
+  });
+});

--- a/src/hooks/useDatabase.js
+++ b/src/hooks/useDatabase.js
@@ -220,20 +220,54 @@ const normalizeUtilityKey = (value) => {
   return UTILITY_KEYS.has(normalized) ? normalized : null;
 };
 
+const sanitizeFiscalYear = (value, fallback = null) => {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    const rounded = Math.round(numeric);
+    if (rounded >= 1900 && rounded <= 9999) {
+      return rounded;
+    }
+  }
+
+  const stringValue = String(value);
+  const parsed = parseInt(stringValue, 10);
+  if (Number.isFinite(parsed) && parsed >= 1900 && parsed <= 9999) {
+    return parsed;
+  }
+
+  const match = stringValue.match(/(19|20)\d{2}/);
+  if (match) {
+    const extracted = Number(match[0]);
+    if (Number.isFinite(extracted) && extracted >= 1900 && extracted <= 9999) {
+      return extracted;
+    }
+  }
+
+  return fallback;
+};
+
 const sanitizeFinancialConfig = (rawConfig = {}) => {
   const currentYear = new Date().getFullYear();
-  const startYear = Number(rawConfig.startYear);
   const projectionYears = Number(rawConfig.projectionYears);
   const startingCashBalance = Number(rawConfig.startingCashBalance);
   const targetCoverageRatio = Number(rawConfig.targetCoverageRatio);
 
   return {
-    startYear: Number.isFinite(startYear) ? startYear : currentYear,
-    projectionYears: Number.isFinite(projectionYears) && projectionYears > 0
-      ? Math.round(projectionYears)
-      : 10,
-    startingCashBalance: Number.isFinite(startingCashBalance) ? startingCashBalance : 0,
-    targetCoverageRatio: Number.isFinite(targetCoverageRatio) ? targetCoverageRatio : 1.5,
+    startYear: sanitizeFiscalYear(rawConfig.startYear, currentYear),
+    projectionYears:
+      Number.isFinite(projectionYears) && projectionYears > 0
+        ? Math.round(projectionYears)
+        : 10,
+    startingCashBalance: Number.isFinite(startingCashBalance)
+      ? startingCashBalance
+      : 0,
+    targetCoverageRatio: Number.isFinite(targetCoverageRatio)
+      ? targetCoverageRatio
+      : 1.5,
   };
 };
 
@@ -363,6 +397,16 @@ const operatingBudgetToRow = (organizationId, utilityKey, row) => {
     ? normalized.expenseLineItems
     : [];
 
+  const normalizedKey = normalizeUtilityKey(utilityKey);
+  const fiscalYear = sanitizeFiscalYear(normalized.year);
+
+  // Supabase enforces a check constraint that fiscal_year must be >= 1900.
+  // If we cannot confidently coerce the provided value into a valid year we
+  // bail out instead of attempting a write that would be rejected.
+  if (!normalizedKey || fiscalYear === null) {
+    return null;
+  }
+
   const sumByIds = (items, ids) =>
     items.reduce((sum, item) => {
       if (!item || !ids.includes(item.id)) {
@@ -394,8 +438,8 @@ const operatingBudgetToRow = (organizationId, utilityKey, row) => {
 
   return {
     organization_id: organizationId,
-    utility_key: normalizeUtilityKey(utilityKey),
-    fiscal_year: Number(normalized.year),
+    utility_key: normalizedKey,
+    fiscal_year: fiscalYear,
     operating_revenue: normalizeNullable(normalized.operatingRevenue) ?? 0,
     non_operating_revenue: normalizeNullable(normalized.nonOperatingRevenue) ?? 0,
     om_expenses: normalizeNullable(omExpenses) ?? 0,
@@ -1413,8 +1457,8 @@ export const useDatabase = (defaultData = {}) => {
       assertCanEdit();
 
       const payload = rows
-        .filter((row) => Number.isFinite(Number(row?.year)))
-        .map((row) => operatingBudgetToRow(organizationId, utilityKey, row));
+        .map((row) => operatingBudgetToRow(organizationId, utilityKey, row))
+        .filter((row) => row && Number.isFinite(row.fiscal_year));
 
       if (!payload.length) {
         return;
@@ -1447,12 +1491,18 @@ export const useDatabase = (defaultData = {}) => {
         .eq('organization_id', organizationId)
         .eq('utility_key', normalizedKey);
 
-      const sanitizedYears = (yearsToKeep || [])
-        .map((value) => Number(value))
-        .filter((value) => Number.isFinite(value));
+      const sanitizedYears = Array.from(
+        new Set(
+          (yearsToKeep || [])
+            .map((value) => sanitizeFiscalYear(value))
+            .filter((value) => value !== null)
+        )
+      );
 
       if (sanitizedYears.length > 0) {
         query = query.not('fiscal_year', 'in', `(${sanitizedYears.join(',')})`);
+      } else {
+        return;
       }
 
       const { error: deleteError } = await query;
@@ -1693,4 +1743,10 @@ export const useDatabase = (defaultData = {}) => {
       importDatabase,
     ]
   );
+};
+
+export const __TEST_ONLY = {
+  sanitizeFinancialConfig,
+  sanitizeFiscalYear,
+  operatingBudgetToRow,
 };


### PR DESCRIPTION
## Summary
- broaden fiscal year sanitization to recover four-digit years embedded in formatted strings
- document the Supabase fiscal year constraint guard within operating budget persistence
- extend unit tests covering the new fiscal year coercion behaviour

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_b_68d37b98ef148329bb3c29b851c34cfb