### PR TITLE
Expand planning and modeling card layouts

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -2532,7 +2532,7 @@ const CapitalPlanningTool = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 p-6">
-      <div className="max-w-7xl mx-auto space-y-6">
+      <div className="max-w-[1600px] mx-auto space-y-6">
         <div className="grid gap-4 md:grid-cols-2">
           {moduleOptions.map((module) => {
             const Icon = module.icon;

--- a/src/components/auth/AuthGate.js
+++ b/src/components/auth/AuthGate.js
@@ -44,7 +44,7 @@ const AuthGate = ({ children }) => {
   return (
     <div className="min-h-screen bg-slate-100 flex flex-col">
       <header className="bg-white border-b border-slate-200 shadow-sm">
-        <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-4 gap-6">
+        <div className="mx-auto flex w-full max-w-[1600px] items-center justify-between px-6 py-4 gap-6">
           <div>
             <h1 className="text-lg font-semibold text-slate-900">Vector</h1>
             <p className="text-xs text-slate-500 uppercase tracking-wide">Capital Planning</p>

--- a/src/components/financial-modeling/FinancialModelingModule.js
+++ b/src/components/financial-modeling/FinancialModelingModule.js
@@ -265,7 +265,7 @@ const FinancialModelingModule = ({
         </div>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 sm:[grid-template-columns:repeat(auto-fit,_minmax(340px,_1fr))]">
         {MODULE_VIEWS.map((view) => {
           const Icon = view.icon;
           const isActive = activeView === view.id;

--- a/src/components/financial-modeling/views/DebtServiceView.js
+++ b/src/components/financial-modeling/views/DebtServiceView.js
@@ -385,7 +385,7 @@ const DebtServiceView = ({
           </p>
 
           <form
-            className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+            className="mt-4 grid grid-cols-1 gap-4 sm:[grid-template-columns:repeat(auto-fit,_minmax(340px,_1fr))]"
             onSubmit={handleAddInstrument}
           >
             <label className="text-sm font-medium text-slate-700">

--- a/src/components/financial-modeling/views/ProFormaView.js
+++ b/src/components/financial-modeling/views/ProFormaView.js
@@ -289,7 +289,7 @@ const ProFormaView = ({ forecastResult, financialConfig }) => {
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 sm:[grid-template-columns:repeat(auto-fit,_minmax(340px,_1fr))]">
         {summaryCards.map((card) => (
           <SummaryCard key={card.title} {...card} />
         ))}

--- a/src/components/financial-modeling/views/SettingsView.js
+++ b/src/components/financial-modeling/views/SettingsView.js
@@ -120,7 +120,7 @@ const SettingsView = ({
           Configure the fiscal window, opening reserves, and policy targets that guide every pro forma scenario.
         </p>
 
-        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:[grid-template-columns:repeat(auto-fit,_minmax(340px,_1fr))]">
           <label className="text-sm font-medium text-slate-700">
             <span>Start Fiscal Year</span>
             <input

--- a/src/components/tabs/StaffAssignmentsTab.js
+++ b/src/components/tabs/StaffAssignmentsTab.js
@@ -428,7 +428,7 @@ const StaffAssignmentsTab = ({
               optimization engine distributes remaining hours.
             </p>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:[grid-template-columns:repeat(auto-fit,_minmax(340px,_1fr))]">
             {summaryCards.map((card) => (
               <div
                 key={card.label}


### PR DESCRIPTION
## Summary
- expand the primary workspace container width to 1600px so planning and modeling screens have more room
- use an auto-fit grid with a 340px minimum card width for summary and navigation cards in planning and modeling views to keep cards wider on large screens

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve 'react-markdown')*

------
https://chatgpt.com/codex/tasks/task_b_68d37e12a5e083298fd7b932d412712b