### PR TITLE
Wire project effort template actions to staff allocations

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -2779,6 +2779,10 @@ const CapitalPlanningTool = () => {
                   staffCategories={staffCategories}
                   staffAllocations={staffAllocations}
                   updateStaffAllocation={updateStaffAllocation}
+                  projectEffortTemplates={projectEffortTemplates}
+                  onSaveProjectEffortTemplate={upsertProjectEffortTemplate}
+                  onDeleteProjectEffortTemplate={removeProjectEffortTemplate}
+                  onApplyEffortTemplate={applyProjectEffortTemplate}
                   fundingSources={fundingSources}
                   isReadOnly={isReadOnly}
                 />


### PR DESCRIPTION
## Summary
- pass project effort template state and handlers into the Staff Allocations tab
- enable saving, deleting, and applying templates from the allocations panel

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_b_68d55aef2c2c8329b6f6afb3d78569ad