### PR TITLE
Add resource planning module and reorganize staffing workflows

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -15,6 +15,7 @@ import {
   FileSpreadsheet,
   ChevronDown,
   LayoutDashboard,
+  Repeat,
 } from "lucide-react";
 
 // Import components
@@ -29,6 +30,7 @@ import PeopleTab from "./tabs/PeopleTab";
 import ScenariosTab from "./tabs/ScenariosTab";
 import ReportsTab from "./tabs/ReportsTab";
 import StaffAssignmentsTab from "./tabs/StaffAssignmentsTab";
+import ProgramEffortTab from "./tabs/ProgramEffortTab";
 import FinancialModelingModule from "./financial-modeling/FinancialModelingModule";
 import { isProjectOrProgram } from "../utils/projectTypes.js";
 
@@ -415,8 +417,8 @@ const CapitalPlanningTool = () => {
     generateDefaultFundingAssumptions(defaultFundingSources)
   );
   const [staffAssignmentOverrides, setStaffAssignmentOverrides] = useState({});
-  const [activeTab, setActiveTab] = useState("overview");
-  const [activeModule, setActiveModule] = useState("planning");
+  const [activeTab, setActiveTab] = useState("capital-overview");
+  const [activeModule, setActiveModule] = useState("capital");
   const [activeDropdown, setActiveDropdown] = useState(null);
   const dropdownRefs = useRef({});
   const [timeHorizon, setTimeHorizon] = useState(60);
@@ -942,12 +944,58 @@ const CapitalPlanningTool = () => {
     [resourceForecast, staffCategories, staffAvailabilityByCategory]
   );
 
+  const DEFAULT_TAB_BY_MODULE = {
+    capital: "capital-overview",
+    resource: "resource-overview",
+  };
+
+  const capitalNavigation = [
+    { id: "capital-overview", label: "Overview", icon: Calendar },
+    {
+      id: "projects",
+      label: "Projects & Programs",
+      icon: FolderOpen,
+    },
+    {
+      id: "schedule",
+      label: "Schedule View",
+      icon: CalendarClock,
+    },
+    { id: "capital-reports", label: "Reports", icon: FileSpreadsheet },
+    { id: "settings", label: "Settings", icon: Settings },
+  ];
+
+  const resourceNavigation = [
+    { id: "resource-overview", label: "Overview", icon: LayoutDashboard },
+    {
+      type: "dropdown",
+      id: "people-menu",
+      label: "People",
+      icon: Users,
+      items: [
+        { id: "people", label: "Staff", icon: UserCircle },
+        { id: "assignments", label: "Assignments", icon: Users },
+        { id: "staff", label: "Categories", icon: Settings },
+      ],
+    },
+    { id: "project-effort", label: "Project Effort", icon: Edit3 },
+    { id: "program-effort", label: "Program Effort", icon: Repeat },
+    { id: "scenarios", label: "Scenarios", icon: GitBranch },
+    { id: "resource-reports", label: "Reports", icon: FileSpreadsheet },
+  ];
+
   const moduleOptions = [
     {
-      id: "planning",
+      id: "capital",
       label: "Capital Planning Workspace",
-      description: "Projects, people, scheduling, and reporting.",
+      description: "Projects, schedules, and portfolio reporting.",
       icon: LayoutDashboard,
+    },
+    {
+      id: "resource",
+      label: "Resource Planning Workspace",
+      description: "People, staffing plans, and utilization insights.",
+      icon: Users,
     },
     {
       id: "financial",
@@ -960,8 +1008,9 @@ const CapitalPlanningTool = () => {
   const handleSelectModule = (moduleId) => {
     setActiveDropdown(null);
     setActiveModule(moduleId);
-    if (moduleId === "planning" && activeTab === "finance") {
-      setActiveTab("overview");
+    const defaultTab = DEFAULT_TAB_BY_MODULE[moduleId];
+    if (defaultTab) {
+      setActiveTab(defaultTab);
     }
   };
 
@@ -2566,7 +2615,7 @@ const CapitalPlanningTool = () => {
           })}
         </div>
 
-        {activeModule === "planning" ? (
+        {activeModule !== "financial" ? (
           <>
             <div className="bg-white rounded-lg shadow-sm relative">
               {isSaving && (
@@ -2577,43 +2626,7 @@ const CapitalPlanningTool = () => {
               )}
               <div className="border-b border-gray-200">
                 <nav className="flex space-x-8 px-6">
-                  {[
-                    { id: "overview", label: "Overview", icon: Calendar },
-                    {
-                      id: "projects",
-                      label: "Projects & Programs",
-                      icon: FolderOpen,
-                    },
-                    {
-                      type: "dropdown",
-                      id: "people-menu",
-                      label: "People",
-                      icon: Users,
-                      items: [
-                        { id: "people", label: "Staff", icon: UserCircle },
-                        { id: "assignments", label: "Assignments", icon: Users },
-                        { id: "staff", label: "Categories", icon: Settings },
-                      ],
-                    },
-                    {
-                      id: "allocations",
-                      label: "Effort Projections",
-                      icon: Edit3,
-                    },
-                    { id: "scenarios", label: "Scenarios", icon: GitBranch },
-                    {
-                      id: "schedule",
-                      label: "Schedule View",
-                      icon: CalendarClock,
-                    },
-                    {
-                      id: "forecast",
-                      label: "Resource Forecast",
-                      icon: AlertTriangle,
-                    },
-                    { id: "reports", label: "Reports", icon: FileSpreadsheet },
-                    { id: "settings", label: "Settings", icon: Settings },
-                  ].map((tab) => {
+                  {(activeModule === "capital" ? capitalNavigation : resourceNavigation).map((tab) => {
                     if (tab.type === "dropdown") {
                       const Icon = tab.icon;
                       const isActive = tab.items.some((item) => item.id === activeTab);
@@ -2709,149 +2722,188 @@ const CapitalPlanningTool = () => {
             </div>
 
             <div className="space-y-6">
-              {activeTab === "overview" && (
-                <Overview
-                  projects={projects}
-                  projectTypes={projectTypes}
-                  staffingGaps={staffingGaps}
-                  projectTimelines={projectTimelines}
-                />
-              )}
-
-              {activeTab === "projects" && (
-                <ProjectsPrograms
-                  projects={projects}
-                  projectTypes={projectTypes}
-                  fundingSources={fundingSources}
-                  staffCategories={staffCategories}
-                  addProject={addProject}
-                  updateProject={updateProject}
-                  deleteProject={deleteProject}
-                  handleImport={handleImport}
-                  isReadOnly={isReadOnly}
-                />
-              )}
-              {activeTab === "staff" && (
-                <StaffCategories
-                  staffCategories={staffCategories}
-                  addStaffCategory={addStaffCategory}
-                  updateStaffCategory={updateStaffCategory}
-                  deleteStaffCategory={deleteStaffCategory}
-                  capacityWarnings={categoryCapacityWarnings}
-                  maxMonthlyFteHours={MAX_MONTHLY_FTE_HOURS}
-                  isReadOnly={isReadOnly}
-                />
-              )}
-
-              {activeTab === "people" && (
-                <PeopleTab
-                  staffMembers={staffMembers}
-                  staffCategories={staffCategories}
-                  addStaffMember={addStaffMember}
-                  updateStaffMember={updateStaffMember}
-                  deleteStaffMember={deleteStaffMember}
-                  staffAvailabilityByCategory={staffAvailabilityByCategory}
-                  isReadOnly={isReadOnly}
-                />
-              )}
-
-              {activeTab === "assignments" && (
-                <StaffAssignmentsTab
-                  projects={projects.filter((project) =>
-                    isProjectOrProgram(project)
+              {activeModule === "capital" && (
+                <>
+                  {activeTab === "capital-overview" && (
+                    <Overview
+                      projects={projects}
+                      projectTypes={projectTypes}
+                      staffingGaps={staffingGaps}
+                      projectTimelines={projectTimelines}
+                      showStaffingGaps={false}
+                    />
                   )}
-                  staffMembers={staffMembers}
-                  staffCategories={staffCategories}
-                  staffAllocations={staffAllocations}
-                  assignmentOverrides={staffAssignmentOverrides}
-                  assignmentPlan={staffAssignmentPlan}
-                  onUpdateAssignment={updateStaffAssignmentOverride}
-                  onResetProjectAssignments={resetProjectAssignments}
-                  staffAvailabilityByCategory={staffAvailabilityByCategory}
-                  isReadOnly={isReadOnly}
-                />
+
+                  {activeTab === "projects" && (
+                    <ProjectsPrograms
+                      projects={projects}
+                      projectTypes={projectTypes}
+                      fundingSources={fundingSources}
+                      staffCategories={staffCategories}
+                      addProject={addProject}
+                      updateProject={updateProject}
+                      deleteProject={deleteProject}
+                      handleImport={handleImport}
+                      isReadOnly={isReadOnly}
+                      enableStaffing={false}
+                    />
+                  )}
+
+                  {activeTab === "schedule" && (
+                    <ScheduleView
+                      projectTimelines={projectTimelines}
+                      projectTypes={projectTypes}
+                      staffCategories={staffCategories}
+                      staffAllocations={staffAllocations}
+                      staffAvailabilityByCategory={staffAvailabilityByCategory}
+                      scheduleHorizon={scheduleHorizon}
+                      setScheduleHorizon={setScheduleHorizon}
+                    />
+                  )}
+
+                  {activeTab === "capital-reports" && (
+                    <ReportsTab
+                      projects={projects}
+                      projectTypes={projectTypes}
+                      fundingSources={fundingSources}
+                      projectTimelines={projectTimelines}
+                      staffCategories={staffCategories}
+                      staffAllocations={staffAllocations}
+                      staffingGaps={staffingGaps}
+                      resourceForecast={resourceForecast}
+                      staffMembers={staffMembers}
+                      staffAssignmentPlan={staffAssignmentPlan}
+                      visibleReports={["cip"]}
+                    />
+                  )}
+
+                  {activeTab === "settings" && (
+                    <SettingsTab
+                      projectTypes={projectTypes}
+                      fundingSources={fundingSources}
+                      addProjectType={addProjectType}
+                      updateProjectType={updateProjectType}
+                      deleteProjectType={deleteProjectType}
+                      addFundingSource={addFundingSource}
+                      updateFundingSource={updateFundingSource}
+                      deleteFundingSource={deleteFundingSource}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
+                </>
               )}
 
-              {activeTab === "allocations" && (
-                <StaffAllocations
-                  projects={projects.filter((p) => p.type === "project")}
-                  projectTypes={projectTypes}
-                  staffCategories={staffCategories}
-                  staffAllocations={staffAllocations}
-                  updateStaffAllocation={updateStaffAllocation}
-                  fundingSources={fundingSources}
-                  isReadOnly={isReadOnly}
-                />
-              )}
+              {activeModule === "resource" && (
+                <>
+                  {activeTab === "resource-overview" && (
+                    <ResourceForecast
+                      resourceForecast={resourceForecast}
+                      staffCategories={staffCategories}
+                      staffingGaps={staffingGaps}
+                      timeHorizon={timeHorizon}
+                      setTimeHorizon={setTimeHorizon}
+                    />
+                  )}
 
-              {activeTab === "scenarios" && (
-                <ScenariosTab
-                  projects={projects}
-                  projectTypes={projectTypes}
-                  staffCategories={staffCategories}
-                  staffAllocations={staffAllocations}
-                  staffAvailabilityByCategory={staffAvailabilityByCategory}
-                  scenarios={scenarios}
-                  activeScenarioId={activeScenarioId}
-                  onSelectScenario={setActiveScenarioId}
-                  onCreateScenario={createScenario}
-                  onDuplicateScenario={duplicateScenario}
-                  onUpdateScenarioMeta={updateScenarioMeta}
-                  onUpdateScenarioAdjustment={updateScenarioAdjustment}
-                  onResetScenarioProject={resetScenarioProject}
-                  timeHorizon={timeHorizon}
-                  isReadOnly={isReadOnly}
-                />
-              )}
+                  {activeTab === "people" && (
+                    <PeopleTab
+                      staffMembers={staffMembers}
+                      staffCategories={staffCategories}
+                      addStaffMember={addStaffMember}
+                      updateStaffMember={updateStaffMember}
+                      deleteStaffMember={deleteStaffMember}
+                      staffAvailabilityByCategory={staffAvailabilityByCategory}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
 
-              {activeTab === "schedule" && (
-                <ScheduleView
-                  projectTimelines={projectTimelines}
-                  projectTypes={projectTypes}
-                  staffCategories={staffCategories}
-                  staffAllocations={staffAllocations}
-                  staffAvailabilityByCategory={staffAvailabilityByCategory}
-                  scheduleHorizon={scheduleHorizon}
-                  setScheduleHorizon={setScheduleHorizon}
-                />
-              )}
-              {activeTab === "forecast" && (
-                <ResourceForecast
-                  resourceForecast={resourceForecast}
-                  staffCategories={staffCategories}
-                  staffingGaps={staffingGaps}
-                  timeHorizon={timeHorizon}
-                  setTimeHorizon={setTimeHorizon}
-                />
-              )}
+                  {activeTab === "assignments" && (
+                    <StaffAssignmentsTab
+                      projects={projects.filter((project) =>
+                        isProjectOrProgram(project)
+                      )}
+                      staffMembers={staffMembers}
+                      staffCategories={staffCategories}
+                      staffAllocations={staffAllocations}
+                      assignmentOverrides={staffAssignmentOverrides}
+                      assignmentPlan={staffAssignmentPlan}
+                      onUpdateAssignment={updateStaffAssignmentOverride}
+                      onResetProjectAssignments={resetProjectAssignments}
+                      staffAvailabilityByCategory={staffAvailabilityByCategory}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
 
-              {activeTab === "reports" && (
-                <ReportsTab
-                  projects={projects}
-                  projectTypes={projectTypes}
-                  fundingSources={fundingSources}
-                  projectTimelines={projectTimelines}
-                  staffCategories={staffCategories}
-                  staffAllocations={staffAllocations}
-                  staffingGaps={staffingGaps}
-                  resourceForecast={resourceForecast}
-                  staffMembers={staffMembers}
-                  staffAssignmentPlan={staffAssignmentPlan}
-                />
-              )}
+                  {activeTab === "staff" && (
+                    <StaffCategories
+                      staffCategories={staffCategories}
+                      addStaffCategory={addStaffCategory}
+                      updateStaffCategory={updateStaffCategory}
+                      deleteStaffCategory={deleteStaffCategory}
+                      capacityWarnings={categoryCapacityWarnings}
+                      maxMonthlyFteHours={MAX_MONTHLY_FTE_HOURS}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
 
-              {activeTab === "settings" && (
-                <SettingsTab
-                  projectTypes={projectTypes}
-                  fundingSources={fundingSources}
-                  addProjectType={addProjectType}
-                  updateProjectType={updateProjectType}
-                  deleteProjectType={deleteProjectType}
-                  addFundingSource={addFundingSource}
-                  updateFundingSource={updateFundingSource}
-                  deleteFundingSource={deleteFundingSource}
-                  isReadOnly={isReadOnly}
-                />
+                  {activeTab === "project-effort" && (
+                    <StaffAllocations
+                      projects={projects.filter((p) => p.type === "project")}
+                      projectTypes={projectTypes}
+                      staffCategories={staffCategories}
+                      staffAllocations={staffAllocations}
+                      updateStaffAllocation={updateStaffAllocation}
+                      fundingSources={fundingSources}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
+
+                  {activeTab === "program-effort" && (
+                    <ProgramEffortTab
+                      programs={projects.filter((p) => p.type === "program")}
+                      projectTypes={projectTypes}
+                      staffCategories={staffCategories}
+                      updateProject={updateProject}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
+
+                  {activeTab === "scenarios" && (
+                    <ScenariosTab
+                      projects={projects}
+                      projectTypes={projectTypes}
+                      staffCategories={staffCategories}
+                      staffAllocations={staffAllocations}
+                      staffAvailabilityByCategory={staffAvailabilityByCategory}
+                      scenarios={scenarios}
+                      activeScenarioId={activeScenarioId}
+                      onSelectScenario={setActiveScenarioId}
+                      onCreateScenario={createScenario}
+                      onDuplicateScenario={duplicateScenario}
+                      onUpdateScenarioMeta={updateScenarioMeta}
+                      onUpdateScenarioAdjustment={updateScenarioAdjustment}
+                      onResetScenarioProject={resetScenarioProject}
+                      timeHorizon={timeHorizon}
+                      isReadOnly={isReadOnly}
+                    />
+                  )}
+
+                  {activeTab === "resource-reports" && (
+                    <ReportsTab
+                      projects={projects}
+                      projectTypes={projectTypes}
+                      fundingSources={fundingSources}
+                      projectTimelines={projectTimelines}
+                      staffCategories={staffCategories}
+                      staffAllocations={staffAllocations}
+                      staffingGaps={staffingGaps}
+                      resourceForecast={resourceForecast}
+                      staffMembers={staffMembers}
+                      staffAssignmentPlan={staffAssignmentPlan}
+                      visibleReports={["cipEffort", "utilization", "gap"]}
+                    />
+                  )}
+                </>
               )}
             </div>
           </>

--- a/src/components/tabs/Overview.js
+++ b/src/components/tabs/Overview.js
@@ -6,6 +6,7 @@ const Overview = ({
   projectTypes,
   staffingGaps,
   projectTimelines,
+  showStaffingGaps = true,
 }) => {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -48,33 +49,35 @@ const Overview = ({
         </div>
 
         {/* Critical Staffing Gaps */}
-        <div className="bg-white p-6 rounded-lg shadow-sm">
-          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <AlertTriangle className="text-red-500" size={20} />
-            Critical Staffing Gaps
-          </h3>
-          <div className="space-y-2 max-h-64 overflow-y-auto">
-            {staffingGaps.slice(0, 10).map((gap, index) => (
-              <div
-                key={index}
-                className="flex justify-between items-center p-2 bg-red-50 rounded"
-              >
-                <div>
-                  <span className="font-medium">{gap.category}</span>
-                  <span className="text-sm text-gray-600 ml-2">
-                    ({gap.monthLabel})
-                  </span>
+        {showStaffingGaps && (
+          <div className="bg-white p-6 rounded-lg shadow-sm">
+            <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <AlertTriangle className="text-red-500" size={20} />
+              Critical Staffing Gaps
+            </h3>
+            <div className="space-y-2 max-h-64 overflow-y-auto">
+              {staffingGaps.slice(0, 10).map((gap, index) => (
+                <div
+                  key={index}
+                  className="flex justify-between items-center p-2 bg-red-50 rounded"
+                >
+                  <div>
+                    <span className="font-medium">{gap.category}</span>
+                    <span className="text-sm text-gray-600 ml-2">
+                      ({gap.monthLabel})
+                    </span>
+                  </div>
+                  <span className="text-red-600 font-medium">-{gap.gap} FTE</span>
                 </div>
-                <span className="text-red-600 font-medium">-{gap.gap} FTE</span>
-              </div>
-            ))}
-            {staffingGaps.length === 0 && (
-              <p className="text-gray-500 text-center py-4">
-                No critical staffing gaps identified
-              </p>
-            )}
+              ))}
+              {staffingGaps.length === 0 && (
+                <p className="text-gray-500 text-center py-4">
+                  No critical staffing gaps identified
+                </p>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Project Timeline */}

--- a/src/components/tabs/ProgramEffortTab.js
+++ b/src/components/tabs/ProgramEffortTab.js
@@ -1,0 +1,376 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Repeat, Users, CalendarClock } from "lucide-react";
+import ProgramStaffingModal from "./ProgramStaffingModal";
+import {
+  sanitizeHoursValue,
+  getVisibleCategoryHours,
+  buildModalStateForProgram,
+  buildCategoryUpdatesForSave,
+} from "../../utils/programStaffing";
+
+const formatHoursSummary = (value) => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return "0";
+  }
+
+  if (Number.isInteger(value)) {
+    return value.toLocaleString("en-US");
+  }
+
+  return value.toLocaleString("en-US", { maximumFractionDigits: 1 });
+};
+
+const defaultModalState = {
+  isOpen: false,
+  programId: null,
+  programName: "",
+  config: {},
+  extraEntries: {},
+  hadExistingValues: false,
+};
+
+const ProgramEffortTab = ({
+  programs = [],
+  projectTypes = [],
+  staffCategories = [],
+  updateProject,
+  isReadOnly = false,
+}) => {
+  const [modalState, setModalState] = useState(defaultModalState);
+
+  const typeMap = useMemo(() => {
+    const entries = new Map();
+    projectTypes.forEach((type) => {
+      if (!type || type.id == null) {
+        return;
+      }
+      entries.set(String(type.id), type);
+    });
+    return entries;
+  }, [projectTypes]);
+
+  const programSummaries = useMemo(() => {
+    return programs
+      .filter((program) => program && program.type === "program")
+      .map((program) => {
+        const categoryHours = getVisibleCategoryHours(program, staffCategories);
+        const categoryCount = Object.keys(categoryHours).length;
+        const totals = {
+          pm: sanitizeHoursValue(program.continuousPmHours),
+          design: sanitizeHoursValue(program.continuousDesignHours),
+          construction: sanitizeHoursValue(program.continuousConstructionHours),
+        };
+        return {
+          program,
+          categoryCount,
+          totals,
+          totalHours: totals.pm + totals.design + totals.construction,
+        };
+      })
+      .sort((a, b) => {
+        const nameA = (a.program?.name || "").toLowerCase();
+        const nameB = (b.program?.name || "").toLowerCase();
+        return nameA.localeCompare(nameB);
+      });
+  }, [programs, staffCategories]);
+
+  const aggregateTotals = useMemo(() => {
+    return programSummaries.reduce(
+      (accumulator, summary) => {
+        accumulator.pm += summary.totals.pm;
+        accumulator.design += summary.totals.design;
+        accumulator.construction += summary.totals.construction;
+        if (summary.categoryCount > 0) {
+          accumulator.configuredPrograms += 1;
+        }
+        return accumulator;
+      },
+      { pm: 0, design: 0, construction: 0, configuredPrograms: 0 }
+    );
+  }, [programSummaries]);
+
+  const openModal = useCallback(
+    (program) => {
+      if (isReadOnly || !program) {
+        return;
+      }
+
+      const { config, extraEntries, hadExistingValues } =
+        buildModalStateForProgram(program, staffCategories);
+
+      setModalState({
+        isOpen: true,
+        programId: program.id,
+        programName: program.name || "Annual program",
+        config,
+        extraEntries,
+        hadExistingValues,
+      });
+    },
+    [isReadOnly, staffCategories]
+  );
+
+  const closeModal = useCallback(() => {
+    setModalState(defaultModalState);
+  }, []);
+
+  const updateModalConfig = useCallback((categoryId, field, value) => {
+    setModalState((previous) => {
+      if (!previous?.isOpen) {
+        return previous;
+      }
+
+      const key = String(categoryId);
+      const entry = previous.config?.[key] || {
+        pmHours: "",
+        designHours: "",
+        constructionHours: "",
+      };
+
+      return {
+        ...previous,
+        config: {
+          ...previous.config,
+          [key]: {
+            ...entry,
+            [field]: value,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const saveModal = useCallback(() => {
+    setModalState((previous) => {
+      if (!previous?.isOpen) {
+        return previous;
+      }
+
+      if (previous.programId == null) {
+        return defaultModalState;
+      }
+
+      if (isReadOnly) {
+        return defaultModalState;
+      }
+
+      const { sanitizedConfig, totals } = buildCategoryUpdatesForSave(
+        previous.config,
+        staffCategories,
+        previous.extraEntries
+      );
+
+      if (sanitizedConfig) {
+        updateProject(previous.programId, {
+          continuousHoursByCategory: sanitizedConfig,
+          continuousPmHours: totals.pm,
+          continuousDesignHours: totals.design,
+          continuousConstructionHours: totals.construction,
+        });
+      } else {
+        updateProject(previous.programId, {
+          continuousHoursByCategory: null,
+          continuousPmHours: 0,
+          continuousDesignHours: 0,
+          continuousConstructionHours: 0,
+        });
+      }
+
+      return defaultModalState;
+    });
+  }, [isReadOnly, staffCategories, updateProject]);
+
+  const clearModal = useCallback(() => {
+    setModalState((previous) => {
+      if (!previous?.isOpen) {
+        return previous;
+      }
+
+      if (isReadOnly) {
+        return defaultModalState;
+      }
+
+      if (previous.programId != null) {
+        updateProject(previous.programId, {
+          continuousHoursByCategory: null,
+          continuousPmHours: 0,
+          continuousDesignHours: 0,
+          continuousConstructionHours: 0,
+        });
+      }
+
+      return defaultModalState;
+    });
+  }, [isReadOnly, updateProject]);
+
+  const totalPrograms = programSummaries.length;
+  const configuredPrograms = aggregateTotals.configuredPrograms;
+  const totalHours =
+    aggregateTotals.pm + aggregateTotals.design + aggregateTotals.construction;
+
+  if (totalPrograms === 0) {
+    return (
+      <div className="rounded-lg bg-white p-6 text-center text-sm text-gray-500 shadow-sm">
+        No annual programs are available yet. Add programs in the Projects &amp;
+        Programs tab to begin managing program-level staffing.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-lg border border-purple-100 bg-purple-50 p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <Repeat className="text-purple-500" size={20} />
+            <div>
+              <p className="text-xs font-semibold uppercase text-purple-600">
+                Annual programs
+              </p>
+              <p className="text-2xl font-bold text-purple-900">{totalPrograms}</p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-lg border border-indigo-100 bg-indigo-50 p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <Users className="text-indigo-500" size={20} />
+            <div>
+              <p className="text-xs font-semibold uppercase text-indigo-600">
+                Programs with staffing
+              </p>
+              <p className="text-2xl font-bold text-indigo-900">{configuredPrograms}</p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-lg border border-blue-100 bg-blue-50 p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <CalendarClock className="text-blue-500" size={20} />
+            <div>
+              <p className="text-xs font-semibold uppercase text-blue-600">
+                Total hours/month
+              </p>
+              <p className="text-2xl font-bold text-blue-900">
+                {formatHoursSummary(totalHours)}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {programSummaries.map(({ program, totals, categoryCount, totalHours }) => {
+          const projectType =
+            program.projectTypeId != null
+              ? typeMap.get(String(program.projectTypeId))
+              : null;
+          const scheduleText =
+            program.programStartDate && program.programEndDate
+              ? `${program.programStartDate} → ${program.programEndDate}`
+              : "Program schedule not set";
+
+          return (
+            <div key={program.id} className="rounded-xl border border-purple-100 bg-white p-6 shadow-sm">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div className="space-y-1">
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    {program.name || "Annual program"}
+                  </h3>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-purple-50 px-2 py-1 font-medium text-purple-700">
+                      <Repeat size={12} /> Annual program
+                    </span>
+                    {projectType && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 font-medium text-gray-700">
+                        <span
+                          className="inline-block h-2 w-2 rounded-full"
+                          style={{ backgroundColor: projectType.color || "#7c3aed" }}
+                        />
+                        {projectType.name}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-500">{scheduleText}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => openModal(program)}
+                  disabled={isReadOnly}
+                  className={`inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                    isReadOnly
+                      ? "cursor-not-allowed bg-gray-200 text-gray-500"
+                      : "bg-purple-600 text-white hover:bg-purple-700 focus:ring-purple-400"
+                  }`}
+                >
+                  Configure staffing
+                </button>
+              </div>
+
+              <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-4">
+                <div className="rounded-lg border border-purple-100 bg-purple-50 p-3 text-purple-800">
+                  <p className="text-xs font-semibold uppercase text-purple-600">
+                    Total hours/mo
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold text-purple-900">
+                    {formatHoursSummary(totalHours)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                  <p className="text-xs font-semibold uppercase text-gray-500">
+                    PM
+                  </p>
+                  <p className="mt-1 text-xl font-semibold text-gray-800">
+                    {formatHoursSummary(totals.pm)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                  <p className="text-xs font-semibold uppercase text-gray-500">
+                    Design
+                  </p>
+                  <p className="mt-1 text-xl font-semibold text-gray-800">
+                    {formatHoursSummary(totals.design)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                  <p className="text-xs font-semibold uppercase text-gray-500">
+                    Construction
+                  </p>
+                  <p className="mt-1 text-xl font-semibold text-gray-800">
+                    {formatHoursSummary(totals.construction)}
+                  </p>
+                </div>
+              </div>
+
+              <p className="mt-4 text-sm text-gray-500">
+                {categoryCount > 0
+                  ? `${categoryCount} ${categoryCount === 1 ? "category" : "categories"} configured`
+                  : "No staffing categories configured yet."}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <ProgramStaffingModal
+        isOpen={modalState.isOpen}
+        programName={modalState.programName}
+        staffCategories={staffCategories}
+        config={modalState.config}
+        onChange={updateModalConfig}
+        onClose={closeModal}
+        onSave={saveModal}
+        onClear={clearModal}
+        hasExistingConfig={
+          modalState.hadExistingValues ||
+          Object.values(modalState.config || {}).some((entry) =>
+            [entry?.pmHours, entry?.designHours, entry?.constructionHours].some(
+              (value) => sanitizeHoursValue(value) > 0
+            )
+          ) ||
+          Object.keys(modalState.extraEntries || {}).length > 0
+        }
+      />
+    </div>
+  );
+};
+
+export default ProgramEffortTab;

--- a/src/components/tabs/ProgramStaffingModal.js
+++ b/src/components/tabs/ProgramStaffingModal.js
@@ -1,0 +1,210 @@
+import React from "react";
+import { X } from "lucide-react";
+import { sanitizeHoursValue } from "../../utils/programStaffing";
+
+const baseInputClass =
+  "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2";
+const programInputClass = `${baseInputClass} focus:border-purple-500 focus:ring-purple-200`;
+
+const ProgramStaffingModal = ({
+  isOpen,
+  programName,
+  staffCategories = [],
+  config = {},
+  onChange,
+  onClose,
+  onSave,
+  onClear,
+  hasExistingConfig,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const sortedCategories = [...staffCategories].sort((a, b) => {
+    const nameA = (a?.name || "").toLowerCase();
+    const nameB = (b?.name || "").toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+
+  const totals = sortedCategories.reduce(
+    (accumulator, category) => {
+      const key = String(category.id);
+      const entry = config?.[key];
+      const pm = sanitizeHoursValue(entry?.pmHours);
+      const design = sanitizeHoursValue(entry?.designHours);
+      const construction = sanitizeHoursValue(entry?.constructionHours);
+
+      accumulator.pm += pm;
+      accumulator.design += design;
+      accumulator.construction += construction;
+      accumulator.total += pm + design + construction;
+
+      if (pm > 0 || design > 0 || construction > 0) {
+        accumulator.categories += 1;
+      }
+
+      return accumulator;
+    },
+    { pm: 0, design: 0, construction: 0, total: 0, categories: 0 }
+  );
+
+  const hasCategories = sortedCategories.length > 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-gray-100 p-6">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-gray-900">
+              Configure staffing by category
+            </h2>
+            <p className="text-sm text-gray-500">
+              Assign monthly PM, design, and construction hours for each staff
+              category supporting <span className="font-medium text-gray-700">{programName || "this program"}</span>.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full bg-gray-100 p-2 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto p-6 pt-4">
+          {hasCategories ? (
+            <table className="min-w-full divide-y divide-gray-100 text-sm">
+              <thead>
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  <th className="px-3 py-2">Staff category</th>
+                  <th className="px-3 py-2">PM hours</th>
+                  <th className="px-3 py-2">Design hours</th>
+                  <th className="px-3 py-2">Construction hours</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {sortedCategories.map((category) => {
+                  const key = String(category.id);
+                  const entry = config?.[key] || {
+                    pmHours: "",
+                    designHours: "",
+                    constructionHours: "",
+                  };
+
+                  return (
+                    <tr key={category.id} className="text-gray-700">
+                      <td className="px-3 py-3 font-medium text-gray-800">
+                        {category.name}
+                      </td>
+                      <td className="px-3 py-3">
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.1"
+                          value={entry.pmHours}
+                          onChange={(event) =>
+                            onChange?.(category.id, "pmHours", event.target.value)
+                          }
+                          className={`${programInputClass} w-full`}
+                        />
+                      </td>
+                      <td className="px-3 py-3">
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.1"
+                          value={entry.designHours}
+                          onChange={(event) =>
+                            onChange?.(category.id, "designHours", event.target.value)
+                          }
+                          className={`${programInputClass} w-full`}
+                        />
+                      </td>
+                      <td className="px-3 py-3">
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.1"
+                          value={entry.constructionHours}
+                          onChange={(event) =>
+                            onChange?.(
+                              category.id,
+                              "constructionHours",
+                              event.target.value
+                            )
+                          }
+                          className={`${programInputClass} w-full`}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : (
+            <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-6 text-center text-sm text-gray-500">
+              No staff categories are available yet. Add categories in the People tab to configure detailed program staffing.
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-gray-100 bg-gray-50 p-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="grid grid-cols-2 gap-3 text-sm text-gray-600 sm:grid-cols-4">
+              <div>
+                <div className="text-xs font-semibold uppercase text-gray-500">Total categories</div>
+                <div className="text-lg font-semibold text-gray-900">{totals.categories}</div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold uppercase text-gray-500">PM hours</div>
+                <div className="text-lg font-semibold text-gray-900">{totals.pm.toFixed(1)}</div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold uppercase text-gray-500">Design hours</div>
+                <div className="text-lg font-semibold text-gray-900">{totals.design.toFixed(1)}</div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold uppercase text-gray-500">Construction hours</div>
+                <div className="text-lg font-semibold text-gray-900">{totals.construction.toFixed(1)}</div>
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <button
+                type="button"
+                onClick={onClear}
+                disabled={!hasExistingConfig}
+                className={`inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition ${
+                  hasExistingConfig
+                    ? "border border-transparent bg-red-50 text-red-600 hover:bg-red-100"
+                    : "cursor-not-allowed border border-transparent bg-gray-200 text-gray-500"
+                }`}
+              >
+                Clear staffing
+              </button>
+              <button
+                type="button"
+                onClick={onSave}
+                className="inline-flex items-center justify-center rounded-md bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-700"
+              >
+                Save configuration
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProgramStaffingModal;

--- a/src/components/tabs/ProjectsPrograms.js
+++ b/src/components/tabs/ProjectsPrograms.js
@@ -596,6 +596,7 @@ const ProgramCard = ({
   deleteProject,
   onConfigureCategoryHours,
   isReadOnly = false,
+  enableStaffing = true,
 }) => {
   const { label: typeLabel, color: typeColor } = getProjectTypeInfo(
     projectTypes,
@@ -842,68 +843,76 @@ const ProgramCard = ({
         </Field>
 
         <div className="md:col-span-2">
-          <Field
-            label="Continuous staffing (hrs per month)"
-            hint={
-              categoryCount > 0
-                ? `Detailed staffing defined for ${categoryCount} ${
-                    categoryCount === 1 ? "category" : "categories"
-                  } • ${formatHoursSummary(totalCategoryHours)} hrs/month total`
-                : "Configure by staff category to define monthly PM, design, and construction hours."
-            }
-          >
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex-1 space-y-4">
-                <div className="flex items-center justify-between rounded-lg border border-purple-200 bg-purple-50 px-4 py-2 text-sm font-semibold text-purple-700 shadow-sm">
-                  <span>Total hours/month</span>
-                  <span className="flex items-baseline gap-1 text-lg font-semibold text-purple-900">
-                    {formatHoursSummary(combinedContinuousHours)}
-                    <span className="text-xs font-medium uppercase text-purple-500">
-                      hrs/mo
+          {enableStaffing ? (
+            <Field
+              label="Continuous staffing (hrs per month)"
+              hint={
+                categoryCount > 0
+                  ? `Detailed staffing defined for ${categoryCount} ${
+                      categoryCount === 1 ? "category" : "categories"
+                    } • ${formatHoursSummary(totalCategoryHours)} hrs/month total`
+                  : "Configure by staff category to define monthly PM, design, and construction hours."
+              }
+            >
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex-1 space-y-4">
+                  <div className="flex items-center justify-between rounded-lg border border-purple-200 bg-purple-50 px-4 py-2 text-sm font-semibold text-purple-700 shadow-sm">
+                    <span>Total hours/month</span>
+                    <span className="flex items-baseline gap-1 text-lg font-semibold text-purple-900">
+                      {formatHoursSummary(combinedContinuousHours)}
+                      <span className="text-xs font-medium uppercase text-purple-500">
+                        hrs/mo
+                      </span>
                     </span>
-                  </span>
+                  </div>
+                  <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    {hoursBreakdown.map((item) => (
+                      <div
+                        key={item.key}
+                        className="rounded-lg border border-purple-100 bg-white p-3 shadow-sm"
+                      >
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-purple-600">
+                          {item.label}
+                        </dt>
+                        <dd className="mt-1 flex items-baseline gap-2 text-2xl font-semibold text-purple-900">
+                          {formatHoursSummary(item.value)}
+                          <span className="text-xs font-medium uppercase text-purple-500">
+                            hrs/mo
+                          </span>
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
                 </div>
-                <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                  {hoursBreakdown.map((item) => (
-                    <div
-                      key={item.key}
-                      className="rounded-lg border border-purple-100 bg-white p-3 shadow-sm"
-                    >
-                      <dt className="text-xs font-semibold uppercase tracking-wide text-purple-600">
-                        {item.label}
-                      </dt>
-                      <dd className="mt-1 flex items-baseline gap-2 text-2xl font-semibold text-purple-900">
-                        {formatHoursSummary(item.value)}
-                        <span className="text-xs font-medium uppercase text-purple-500">
-                          hrs/mo
-                        </span>
-                      </dd>
-                    </div>
-                  ))}
-                </dl>
+                <div className="sm:pl-4 sm:pt-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (isReadOnly) {
+                        return;
+                      }
+                      onConfigureCategoryHours?.(program);
+                    }}
+                    disabled={isReadOnly}
+                    className={`inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-3 text-sm font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 sm:w-auto ${
+                      isReadOnly
+                        ? "bg-gray-200 text-gray-500 cursor-not-allowed"
+                        : "bg-purple-600 text-white transition hover:bg-purple-700 focus:ring-purple-400"
+                    }`}
+                  >
+                    <SlidersHorizontal size={16} className="text-purple-100" />
+                    Configure by staff category
+                  </button>
+                </div>
               </div>
-              <div className="sm:pl-4 sm:pt-1">
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (isReadOnly) {
-                      return;
-                    }
-                    onConfigureCategoryHours?.(program);
-                  }}
-                  disabled={isReadOnly}
-                  className={`inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-3 text-sm font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-1 sm:w-auto ${
-                    isReadOnly
-                      ? "bg-gray-200 text-gray-500 cursor-not-allowed"
-                      : "bg-purple-600 text-white transition hover:bg-purple-700 focus:ring-purple-400"
-                  }`}
-                >
-                  <SlidersHorizontal size={16} className="text-purple-100" />
-                  Configure by staff category
-                </button>
+            </Field>
+          ) : (
+            <Field label="Continuous staffing (hrs per month)">
+              <div className="rounded-lg border border-dashed border-purple-200 bg-purple-50 p-4 text-sm text-purple-700">
+                Staffing configuration is managed from the Resource Planning module. Use the Program Effort tab to define hours by staff category.
               </div>
-            </div>
-          </Field>
+            </Field>
+          )}
         </div>
       </div>
     </div>
@@ -1162,6 +1171,7 @@ const ProjectsPrograms = ({
   deleteProject,
   handleImport,
   isReadOnly = false,
+  enableStaffing = true,
 }) => {
   const projectGroups = useMemo(
     () => groupProjectsByType(projects, projectTypes),
@@ -1187,7 +1197,7 @@ const ProjectsPrograms = ({
 
   const openCategoryModal = useCallback(
     (program) => {
-      if (!program) {
+      if (!enableStaffing || !program) {
         return;
       }
 
@@ -1203,7 +1213,7 @@ const ProjectsPrograms = ({
         hadExistingValues,
       });
     },
-    [staffCategories]
+    [enableStaffing, staffCategories]
   );
 
   const closeCategoryModal = useCallback(() => {
@@ -1242,6 +1252,10 @@ const ProjectsPrograms = ({
         return previous;
       }
 
+      if (!enableStaffing) {
+        return defaultCategoryModalState;
+      }
+
       const { sanitizedConfig, totals } = buildCategoryUpdatesForSave(
         previous.config,
         staffCategories,
@@ -1268,12 +1282,16 @@ const ProjectsPrograms = ({
 
       return defaultCategoryModalState;
     });
-  }, [staffCategories, updateProject]);
+  }, [enableStaffing, staffCategories, updateProject]);
 
   const clearCategoryModal = useCallback(() => {
     setCategoryModalState((previous) => {
       if (!previous?.isOpen) {
         return previous;
+      }
+
+      if (!enableStaffing) {
+        return defaultCategoryModalState;
       }
 
       if (previous.programId != null) {
@@ -1287,7 +1305,7 @@ const ProjectsPrograms = ({
 
       return defaultCategoryModalState;
     });
-  }, [updateProject]);
+  }, [enableStaffing, updateProject]);
 
   const toggleGroup = (key) => {
     setExpandedGroups((previous) => ({
@@ -1502,8 +1520,11 @@ const ProjectsPrograms = ({
                               staffCategories={staffCategories}
                               updateProject={updateProject}
                               deleteProject={deleteProject}
-                              onConfigureCategoryHours={openCategoryModal}
+                              onConfigureCategoryHours={
+                                enableStaffing ? openCategoryModal : undefined
+                              }
                               isReadOnly={isReadOnly}
+                              enableStaffing={enableStaffing}
                             />
                         ))}
                       </div>
@@ -1543,25 +1564,27 @@ const ProjectsPrograms = ({
         </div>
       </div>
 
-      <CategoryHoursModal
-        isOpen={categoryModalState.isOpen}
-        programName={categoryModalState.programName}
-        staffCategories={staffCategories}
-        config={categoryModalState.config}
-        onChange={updateModalConfig}
-        onClose={closeCategoryModal}
-        onSave={saveCategoryModal}
-        onClear={clearCategoryModal}
-        hasExistingConfig={
-          categoryModalState.hadExistingValues ||
-          Object.values(categoryModalState.config || {}).some((entry) =>
-            [entry?.pmHours, entry?.designHours, entry?.constructionHours].some(
-              (value) => sanitizeHoursValue(value) > 0
-            )
-          ) ||
-          Object.keys(categoryModalState.extraEntries || {}).length > 0
-        }
-      />
+      {enableStaffing && (
+        <CategoryHoursModal
+          isOpen={categoryModalState.isOpen}
+          programName={categoryModalState.programName}
+          staffCategories={staffCategories}
+          config={categoryModalState.config}
+          onChange={updateModalConfig}
+          onClose={closeCategoryModal}
+          onSave={saveCategoryModal}
+          onClear={clearCategoryModal}
+          hasExistingConfig={
+            categoryModalState.hadExistingValues ||
+            Object.values(categoryModalState.config || {}).some((entry) =>
+              [entry?.pmHours, entry?.designHours, entry?.constructionHours].some(
+                (value) => sanitizeHoursValue(value) > 0
+              )
+            ) ||
+            Object.keys(categoryModalState.extraEntries || {}).length > 0
+          }
+        />
+      )}
     </div>
   );
 };

--- a/src/components/tabs/ReportsTab.js
+++ b/src/components/tabs/ReportsTab.js
@@ -81,7 +81,13 @@ const ReportsTab = ({
   resourceForecast = [],
   staffMembers = [],
   staffAssignmentPlan = null,
+  visibleReports = ["cip", "cipEffort", "gap", "utilization"],
 }) => {
+  const showReport = useCallback(
+    (key) => visibleReports.includes(key),
+    [visibleReports]
+  );
+
   const formatCount = (value) => {
     const numeric = Number(value);
     if (!Number.isFinite(numeric)) {
@@ -414,7 +420,8 @@ const ReportsTab = ({
       </div>
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <ReportCard
+        {showReport("cip") && (
+          <ReportCard
           title="Capital Improvement Plan"
           description="Portfolio-level export summarizing each project and program with schedule, budget, and delivery details."
           icon={FileSpreadsheet}
@@ -429,9 +436,11 @@ const ReportsTab = ({
               onClick: handleCipPdfDownload,
             },
           ]}
-        />
+          />
+        )}
 
-        <ReportCard
+        {showReport("cipEffort") && (
+          <ReportCard
           title="CIP Effort by Category"
           description="Detailed view of planned hours, FTE, and costs for every project-category combination to support resource planning."
           icon={BarChart3}
@@ -442,9 +451,11 @@ const ReportsTab = ({
               onClick: () => downloadReport(cipEffortReport),
             },
           ]}
-        />
+          />
+        )}
 
-        <ReportCard
+        {showReport("utilization") && (
+          <ReportCard
           title="Staff Utilization"
           description="Optimized and manual staff assignments by project and phase, with visibility into overrides and unmet demand."
           icon={Users}
@@ -459,9 +470,11 @@ const ReportsTab = ({
               onClick: handleStaffUtilizationPdfDownload,
             },
           ]}
-        />
+          />
+        )}
 
-        <ReportCard
+        {showReport("gap") && (
+          <ReportCard
           title="Staffing Gap Analysis"
           description="Month-by-month shortage report highlighting where demand exceeds available staffing capacity."
           icon={AlertTriangle}
@@ -476,7 +489,8 @@ const ReportsTab = ({
               onClick: () => downloadReport(gapReport),
             },
           ]}
-        />
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/tabs/StaffAssignmentsTab.js
+++ b/src/components/tabs/StaffAssignmentsTab.js
@@ -453,7 +453,7 @@ const StaffAssignmentsTab = ({
         <div className="rounded-lg border border-dashed border-gray-300 bg-white p-10 text-center text-gray-500">
           <p className="text-sm">
             No staffing demand has been defined yet. Add effort projections on
-            the Effort Projections tab to begin assigning individual staff.
+            the Project Effort tab to begin assigning individual staff.
           </p>
         </div>
       ) : (

--- a/src/utils/programStaffing.js
+++ b/src/utils/programStaffing.js
@@ -1,0 +1,173 @@
+const sanitizeHoursValue = (value) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 0;
+};
+
+const parseCategoryHoursConfig = (config) => {
+  if (!config) {
+    return {};
+  }
+
+  if (typeof config === "string") {
+    try {
+      const parsed = JSON.parse(config);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch (error) {
+      console.warn("Unable to parse program hours config:", error);
+      return {};
+    }
+  }
+
+  return typeof config === "object" ? config : {};
+};
+
+const sanitizeCategoryHoursMap = (config) => {
+  const parsed = parseCategoryHoursConfig(config);
+  const sanitized = {};
+
+  Object.entries(parsed).forEach(([key, value]) => {
+    if (!value || typeof value !== "object") {
+      return;
+    }
+
+    const pmHours = sanitizeHoursValue(value.pmHours);
+    const designHours = sanitizeHoursValue(value.designHours);
+    const constructionHours = sanitizeHoursValue(value.constructionHours);
+
+    if (pmHours > 0 || designHours > 0 || constructionHours > 0) {
+      sanitized[String(key)] = { pmHours, designHours, constructionHours };
+    }
+  });
+
+  return sanitized;
+};
+
+const getVisibleCategoryHours = (program, staffCategories = []) => {
+  const sanitized = sanitizeCategoryHoursMap(program?.continuousHoursByCategory);
+
+  if (!Array.isArray(staffCategories) || staffCategories.length === 0) {
+    return sanitized;
+  }
+
+  const validCategoryIds = new Set(
+    staffCategories
+      .filter((category) => category && category.id != null)
+      .map((category) => String(category.id))
+  );
+
+  return Object.entries(sanitized).reduce((accumulator, [key, value]) => {
+    if (validCategoryIds.has(key)) {
+      accumulator[key] = value;
+    }
+    return accumulator;
+  }, {});
+};
+
+const buildModalStateForProgram = (program, staffCategories = []) => {
+  const sanitized = sanitizeCategoryHoursMap(program?.continuousHoursByCategory);
+  const config = {};
+  const extraEntries = {};
+  const knownCategoryIds = new Set();
+
+  (staffCategories || []).forEach((category) => {
+    if (!category || category.id == null) {
+      return;
+    }
+
+    const key = String(category.id);
+    knownCategoryIds.add(key);
+    const entry = sanitized[key];
+    config[key] = {
+      pmHours: entry ? String(entry.pmHours) : "",
+      designHours: entry ? String(entry.designHours) : "",
+      constructionHours: entry ? String(entry.constructionHours) : "",
+    };
+  });
+
+  Object.entries(sanitized).forEach(([key, entry]) => {
+    if (!knownCategoryIds.has(key)) {
+      extraEntries[key] = entry;
+    }
+  });
+
+  return {
+    config,
+    extraEntries,
+    hadExistingValues: Object.keys(sanitized).length > 0,
+  };
+};
+
+const buildCategoryUpdatesForSave = (
+  draftConfig,
+  staffCategories = [],
+  extraEntries = {}
+) => {
+  const mergedConfig = {};
+  let totalPm = 0;
+  let totalDesign = 0;
+  let totalConstruction = 0;
+
+  const addEntry = (key, entry) => {
+    if (!entry) {
+      return;
+    }
+
+    const pmHours = sanitizeHoursValue(entry.pmHours);
+    const designHours = sanitizeHoursValue(entry.designHours);
+    const constructionHours = sanitizeHoursValue(entry.constructionHours);
+
+    if (pmHours > 0 || designHours > 0 || constructionHours > 0) {
+      mergedConfig[String(key)] = { pmHours, designHours, constructionHours };
+      totalPm += pmHours;
+      totalDesign += designHours;
+      totalConstruction += constructionHours;
+    }
+  };
+
+  (staffCategories || []).forEach((category) => {
+    if (!category || category.id == null) {
+      return;
+    }
+
+    const key = String(category.id);
+    const entry = draftConfig?.[key];
+
+    if (!entry) {
+      return;
+    }
+
+    addEntry(key, {
+      pmHours: entry.pmHours,
+      designHours: entry.designHours,
+      constructionHours: entry.constructionHours,
+    });
+  });
+
+  Object.entries(extraEntries || {}).forEach(([key, entry]) => {
+    if (mergedConfig[key]) {
+      return;
+    }
+
+    addEntry(key, entry);
+  });
+
+  return {
+    sanitizedConfig:
+      Object.keys(mergedConfig).length > 0 ? mergedConfig : null,
+    totals: {
+      pm: totalPm,
+      design: totalDesign,
+      construction: totalConstruction,
+      total: totalPm + totalDesign + totalConstruction,
+    },
+  };
+};
+
+export {
+  sanitizeHoursValue,
+  parseCategoryHoursConfig,
+  sanitizeCategoryHoursMap,
+  getVisibleCategoryHours,
+  buildModalStateForProgram,
+  buildCategoryUpdatesForSave,
+};


### PR DESCRIPTION
## Summary
- add a dedicated Resource Planning module with updated navigation, moving people, effort, scenarios, and forecasting functionality out of Capital Planning
- create reusable program staffing modal utilities and a new Program Effort tab while removing staffing configuration from the Capital Projects & Programs tab
- scope reports to modules, add overview configuration for staffing gaps, and allow ReportsTab to filter visible reports for capital vs resource planning needs

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_b_68d55cf81f148329b34cdae839cce2d5