### PR TITLE
Adjust module selection layout

### DIFF
--- a/src/components/CapitalPlanningTool.js
+++ b/src/components/CapitalPlanningTool.js
@@ -2582,7 +2582,7 @@ const CapitalPlanningTool = () => {
   return (
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-[1600px] mx-auto space-y-6">
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {moduleOptions.map((module) => {
             const Icon = module.icon;
             const isActive = activeModule === module.id;


### PR DESCRIPTION
## Summary
- show all module buttons on a single row by using a three-column grid on medium+ screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5d7d0157483298e491bcdacd8344e